### PR TITLE
Retain fetch roles cache for 5 minutes instead of 1 second

### DIFF
--- a/packages/app/app/[mod]/page.tsx
+++ b/packages/app/app/[mod]/page.tsx
@@ -18,7 +18,7 @@ export default async function ModPage({ params }: { params: { mod: string } }) {
     notFound()
   }
 
-  const data = await fetchRolesMod(mod, { next: { revalidate: 1 } })
+  const data = await fetchRolesMod(mod, { next: { revalidate: 60 * 5 } }) // 5 minutes cache retention
   if (!data) {
     notFound()
   }

--- a/packages/app/components/RoleView/fetching.ts
+++ b/packages/app/components/RoleView/fetching.ts
@@ -19,7 +19,7 @@ export const fetchOrInitRole = async ({ address, chainId, roleKey }: Props) => {
     // Otherwise we show a 404.
     const modExists = await fetchRolesMod(
       { address, chainId },
-      { next: { revalidate: 1 } }
+      { next: { revalidate: 60 * 5 } } // 5 minutes cache retention
     )
     if (!modExists) {
       notFound()


### PR DESCRIPTION
I picked 5 minutes as it seems like enough time for handling traffic spikes and test deployment use, but not too long for someone to wait on a recently deployed instance.

Does it feel like too long to you?