### PR TITLE
Fix Roles Module Proxy Address calculation

### DIFF
--- a/packages/sdk/src/setup.ts
+++ b/packages/sdk/src/setup.ts
@@ -132,7 +132,7 @@ export const setUpRolesMod = ({
   }
 
   // calculate deterministic proxy address for extra config calls
-  const proxyAddress = calculateProxyAddress(deployModuleCalldata, saltNonce)
+  const proxyAddress = calculateProxyAddress(setUpCalldata, saltNonce)
 
   // calls for setting up multiSend transaction unwrapping
   const MULTISEND_SELECTOR = "0x8d80ff0a"


### PR DESCRIPTION
When using setUpRolesMod the predicted Roles Module Proxy Address is not computed correctly. The multicall transaction still goes through because it "sets" permissions on an empty account, which does not revert.