### PR TITLE
Fix preset handling bug and add `splitTargets` sdk function

### DIFF
--- a/packages/app/components/permissions/PresetItem/Parameter.tsx
+++ b/packages/app/components/permissions/PresetItem/Parameter.tsx
@@ -10,10 +10,11 @@ const Parameter: React.FC<{
 }> = ({ parameter, queryParams, pathParams }) => {
   // we only support path and query parameters
   if (parameter.in !== "path" && parameter.in !== "query") return null
-  const value =
+  const value = (
     parameter.in === "path"
       ? pathParams[parameter.name]
       : queryParams[parameter.name]
+  ) as string | number | string[] | number[] | undefined
 
   return (
     <LabeledData
@@ -25,14 +26,18 @@ const Parameter: React.FC<{
         <ArrayInput
           readOnly
           value={
-            Array.isArray(value) ? value : ([value] as string[] | number[])
+            value
+              ? Array.isArray(value)
+                ? value
+                : ([value] as string[] | number[])
+              : undefined
           }
         />
       ) : (
         <input
           type="text"
           readOnly
-          value={value.toString()}
+          value={value ? value.toString() : ""}
           className={classes.parameterInput}
         />
       )}
@@ -44,11 +49,11 @@ export default Parameter
 
 const ArrayInput: React.FC<{
   readOnly: boolean
-  value: string[] | number[]
+  value: string[] | number[] | undefined
 }> = ({ readOnly, value }) => {
   return (
     <Flex gap={2} direction="column">
-      {value.map((item, i) => (
+      {value?.map((item, i) => (
         <input
           key={i}
           type="text"

--- a/packages/app/components/permissions/PresetItem/index.tsx
+++ b/packages/app/components/permissions/PresetItem/index.tsx
@@ -15,7 +15,6 @@ interface Props {
 
 const PresetItem: React.FC<Props> = ({ preset, chainId, diff }) => {
   const presetDiff = diff?.get(preset)
-  console.log({ presetDiff })
   return <PresetItemMain {...{ preset, chainId, diff }} />
 }
 

--- a/packages/app/components/permissions/annotations.test.ts
+++ b/packages/app/components/permissions/annotations.test.ts
@@ -44,9 +44,23 @@ describe("processAnnotations()", () => {
                 "schema": {
                   "deprecated": false,
                   "items": {
+                    "anyOf": [
+                      {
+                        "deprecated": false,
+                        "nullable": false,
+                        "type": "string",
+                      },
+                      {
+                        "deprecated": false,
+                        "enum": [
+                          "ETH",
+                        ],
+                        "nullable": false,
+                        "type": "string",
+                      },
+                    ],
                     "deprecated": false,
                     "nullable": false,
-                    "type": "string",
                   },
                   "nullable": false,
                   "type": "array",
@@ -59,13 +73,27 @@ describe("processAnnotations()", () => {
                 "explode": false,
                 "in": "query",
                 "name": "buy",
-                "required": false,
+                "required": true,
                 "schema": {
                   "deprecated": false,
                   "items": {
+                    "anyOf": [
+                      {
+                        "deprecated": false,
+                        "nullable": false,
+                        "type": "string",
+                      },
+                      {
+                        "deprecated": false,
+                        "enum": [
+                          "ETH",
+                        ],
+                        "nullable": false,
+                        "type": "string",
+                      },
+                    ],
                     "deprecated": false,
                     "nullable": false,
-                    "type": "string",
                   },
                   "nullable": false,
                   "type": "array",
@@ -157,7 +185,7 @@ describe("processAnnotations()", () => {
                         "paramType": 0,
                       },
                       {
-                        "operator": 0,
+                        "operator": 15,
                         "paramType": 1,
                       },
                       {
@@ -254,7 +282,7 @@ describe("processAnnotations()", () => {
                         "paramType": 0,
                       },
                       {
-                        "operator": 0,
+                        "operator": 15,
                         "paramType": 1,
                       },
                       {
@@ -431,7 +459,7 @@ const permissionsForPreset1: PermissionCoerced[] = [
                 },
               ],
             },
-            { paramType: 1, operator: 0 },
+            { paramType: 1, operator: 15 },
             { paramType: 1, operator: 0 },
             { paramType: 1, operator: 0 },
             { paramType: 1, operator: 0 },
@@ -496,7 +524,7 @@ const permissionsForPreset1: PermissionCoerced[] = [
                 },
               ],
             },
-            { paramType: 1, operator: 0 },
+            { paramType: 1, operator: 15 },
             { paramType: 1, operator: 0 },
             { paramType: 1, operator: 0 },
             { paramType: 1, operator: 0 },

--- a/packages/sdk/src/conditions/normalizeCondition.ts
+++ b/packages/sdk/src/conditions/normalizeCondition.ts
@@ -277,7 +277,7 @@ const pushDownLogicalConditions = (condition: Condition): Condition => {
  * @returns the index of the hinge node. If there are differences in more than a single index, returns `null`.
  * @throws If the conditions would not pass integrity checks.
  **/
-const findMatchesHingeIndex = (conditions: Condition[]) => {
+const findMatchesHingeIndex = (conditions: readonly Condition[]) => {
   // use first branch as reference and check if the others are equivalent beyond a single nested hinge node
   let hingeNodeIndex: number | null = null
 
@@ -314,7 +314,7 @@ const findMatchesHingeIndex = (conditions: Condition[]) => {
  * Given a set of AND conditions, check that their children are equal beyond a single hinge node in each branch. A hinge branch index of `-1` indicate a missing branch that is present in the other AND conditions.
  * @returns the indices of the hinge branches for the respective AND conditions. If there are differences in more than a single branch, returns `null`.
  **/
-const findAndHingeIndices = (conditions: Condition[]) => {
+const findAndHingeIndices = (conditions: readonly Condition[]) => {
   const allChildrenIds = conditions.map((condition) => {
     if (!condition.children) throw new Error("empty children")
     return condition.children.map(conditionId)

--- a/packages/sdk/src/permissions/reconstructPermissions.ts
+++ b/packages/sdk/src/permissions/reconstructPermissions.ts
@@ -12,7 +12,7 @@ import {
  * @returns A set of permissions that produces these targets when processed
  */
 export const reconstructPermissions = (
-  targets: Target[]
+  targets: readonly Target[]
 ): PermissionCoerced[] => {
   return targets.flatMap((target) => {
     if (target.clearance === Clearance.None) {

--- a/packages/sdk/src/targets/diffTargets.ts
+++ b/packages/sdk/src/targets/diffTargets.ts
@@ -4,7 +4,10 @@ import { Clearance, Target, Function, Condition } from "../types"
 /**
  *  Returns targets granted by `a` that are not granted by `b`
  */
-export const diffTargets = (a: Target[], b: Target[]): Target[] => {
+export const diffTargets = (
+  a: readonly Target[],
+  b: readonly Target[]
+): Target[] => {
   // targets in a that are not in b
   const targetsDiff = a.filter(
     (targetA) => !b.some((targetB) => targetsEqual(targetA, targetB))

--- a/packages/sdk/src/targets/index.ts
+++ b/packages/sdk/src/targets/index.ts
@@ -1,3 +1,4 @@
 export { applyTargets } from "./applyTargets"
 export { checkIntegrity } from "./checkIntegrity"
 export { diffTargets } from "./diffTargets"
+export { splitTargets } from "./splitTargets"

--- a/packages/sdk/src/targets/splitTargets.ts
+++ b/packages/sdk/src/targets/splitTargets.ts
@@ -1,0 +1,53 @@
+/**
+ *  Splits targets `a` granted by `a` that are not granted by `b`
+ */
+
+import { splitCondition } from "../conditions"
+import { Target } from "../types"
+
+import { diffTargets } from "./diffTargets"
+
+/**
+ * Given two sets of targets, split targets in the first `combined` set into the `split` set and the remainder. Returns the remainder targets.
+ * Targets appearing in `combined` and `split` will have their conditions split so that the combination of the `split` and `remainder` targets is equal to `combined`.
+ * @returns All targets from `combined` that are not included in `split`.
+ * @throws If it is impossible to split the condition of a target present in `combined` and `split`.
+ */
+export const splitTargets = (
+  combined: readonly Target[],
+  split: readonly Target[]
+): Target[] => {
+  const remainder = diffTargets(combined, split)
+
+  // For the remaining targets, split conditions so that the remaining condition branches don't include any of those that are already in `split`
+  return remainder.map((target) => {
+    const targetInSplit = split.find((t) => t.address === target.address)
+    if (!targetInSplit) return target
+
+    return {
+      ...target,
+      functions: target.functions.map((func) => {
+        const funcInSplit = targetInSplit.functions.find(
+          (f) => f.selector === func.selector
+        )
+        if (!funcInSplit) return func
+
+        if (!funcInSplit.condition || !func.condition) {
+          // if function targets remain, they must have a condition in which they differ
+          throw new Error("invariant violation")
+        }
+
+        const remainderCondition = splitCondition(
+          func.condition,
+          funcInSplit.condition
+        )
+        if (!remainderCondition) throw new Error("invariant violation")
+
+        return {
+          ...func,
+          condition: remainderCondition,
+        }
+      }),
+    }
+  })
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -85,7 +85,7 @@ export interface Target {
   address: `0x${string}`
   clearance: Clearance
   executionOptions: ExecutionOptions
-  functions: Function[]
+  functions: readonly Function[]
 }
 
 export interface Function {
@@ -99,7 +99,7 @@ export interface Condition {
   paramType: ParameterType
   operator: Operator
   compValue?: `0x${string}`
-  children?: Condition[]
+  children?: readonly Condition[]
 }
 
 export interface Allowance {

--- a/packages/sdk/test/splitTargets.test.ts
+++ b/packages/sdk/test/splitTargets.test.ts
@@ -1,0 +1,678 @@
+import { expect } from "chai"
+
+import {
+  Permission,
+  processPermissions,
+  reconstructPermissions,
+} from "../src/permissions"
+import { diffTargets, splitTargets } from "../src/targets"
+
+describe("splitTargets", () => {
+  it("splits so that both shares combined yield the original permissions", () => {
+    const { targets: combinedTargets } = processPermissions(combinedPermissions)
+    const { targets: split } = processPermissions(splitPermissions)
+
+    const remainderTargets = splitTargets(combinedTargets, split)
+    const remainingPermissions = reconstructPermissions(remainderTargets)
+
+    const { targets: finalTargets } = processPermissions([
+      ...splitPermissions,
+      ...remainingPermissions,
+    ])
+
+    expect(diffTargets(finalTargets, combinedTargets)).to.have.length(0)
+    expect(diffTargets(combinedTargets, finalTargets)).to.have.length(0)
+  })
+})
+
+const combinedPermissions: Permission[] = [
+  {
+    targetAddress: "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
+    selector: "0x095ea7b3",
+    send: false,
+    delegatecall: false,
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x000000000000000000000000c92e8bdf79f0507f65a392b0ab4667716bfe0110",
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+    selector: "0x095ea7b3",
+    send: false,
+    delegatecall: false,
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 0,
+          operator: 2,
+          children: [
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x000000000000000000000000c92e8bdf79f0507f65a392b0ab4667716bfe0110",
+            },
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x0000000000000000000000000fec3d212bcc29ef3e505b555d7a7343df0b7f76",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x23da9ade38e4477b23770ded512fd37b12381fab",
+    selector: "0x569d3489",
+    send: false,
+    delegatecall: true,
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 3,
+          operator: 5,
+          children: [
+            {
+              paramType: 0,
+              operator: 2,
+              children: [
+                {
+                  paramType: 1,
+                  operator: 16,
+                  compValue:
+                    "0x000000000000000000000000cb444e90d8198415266c6a2724b7900fb12fc56e",
+                },
+                {
+                  paramType: 1,
+                  operator: 16,
+                  compValue:
+                    "0x000000000000000000000000ddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+                },
+              ],
+            },
+            {
+              paramType: 0,
+              operator: 2,
+              children: [
+                {
+                  paramType: 1,
+                  operator: 16,
+                  compValue:
+                    "0x000000000000000000000000cb444e90d8198415266c6a2724b7900fb12fc56e",
+                },
+                {
+                  paramType: 1,
+                  operator: 16,
+                  compValue:
+                    "0x000000000000000000000000ddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+                },
+              ],
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x23da9ade38e4477b23770ded512fd37b12381fab",
+    selector: "0x5a66c223",
+    send: false,
+    delegatecall: true,
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 3,
+          operator: 5,
+          children: [
+            {
+              paramType: 0,
+              operator: 2,
+              children: [
+                {
+                  paramType: 1,
+                  operator: 16,
+                  compValue:
+                    "0x000000000000000000000000cb444e90d8198415266c6a2724b7900fb12fc56e",
+                },
+                {
+                  paramType: 1,
+                  operator: 16,
+                  compValue:
+                    "0x000000000000000000000000ddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+                },
+              ],
+            },
+            {
+              paramType: 0,
+              operator: 2,
+              children: [
+                {
+                  paramType: 1,
+                  operator: 16,
+                  compValue:
+                    "0x000000000000000000000000cb444e90d8198415266c6a2724b7900fb12fc56e",
+                },
+                {
+                  paramType: 1,
+                  operator: 16,
+                  compValue:
+                    "0x000000000000000000000000ddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+                },
+              ],
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x2086f52651837600180de173b09470f54ef74910",
+    selector: "0x095ea7b3",
+    send: false,
+    delegatecall: false,
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 0,
+          operator: 2,
+          children: [
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x00000000000000000000000098ef32edd24e2c92525e59afc4475c1242a30184",
+            },
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x0000000000000000000000000fec3d212bcc29ef3e505b555d7a7343df0b7f76",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x98ef32edd24e2c92525e59afc4475c1242a30184",
+    selector: "0x43a0d066",
+    send: false,
+    delegatecall: false,
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x000000000000000000000000000000000000000000000000000000000000000a",
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x0821ed041620b83b306ffac74df3fa855cede51a",
+    selector: "0xc32e7202",
+    send: false,
+    delegatecall: false,
+  },
+  {
+    targetAddress: "0x0821ed041620b83b306ffac74df3fa855cede51a",
+    selector: "0x3d18b912",
+    send: false,
+    delegatecall: false,
+  },
+  {
+    targetAddress: "0x0821ed041620b83b306ffac74df3fa855cede51a",
+    selector: "0x7050ccd9",
+    send: false,
+    delegatecall: false,
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 15,
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x4ecaba5870353805a9f068101a40e0f32ed605c6",
+    selector: "0x095ea7b3",
+    send: false,
+    delegatecall: false,
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x0000000000000000000000000fec3d212bcc29ef3e505b555d7a7343df0b7f76",
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
+    selector: "0x095ea7b3",
+    send: false,
+    delegatecall: false,
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x0000000000000000000000000fec3d212bcc29ef3e505b555d7a7343df0b7f76",
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x0fec3d212bcc29ef3e505b555d7a7343df0b7f76",
+    selector: "0x9eba6619",
+    send: false,
+    delegatecall: false,
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x0000000000000000000000000821ed041620b83b306ffac74df3fa855cede51a",
+        },
+        {
+          paramType: 0,
+          operator: 2,
+          children: [
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x0000000000000000000000002086f52651837600180de173b09470f54ef74910",
+            },
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x000000000000000000000000e91d153e0b41518a2ce8dd3d7944fa863463a97d",
+            },
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x0000000000000000000000004ecaba5870353805a9f068101a40e0f32ed605c6",
+            },
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x000000000000000000000000ddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+            },
+          ],
+        },
+        {
+          paramType: 1,
+          operator: 0,
+        },
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x2086f52651837600180de173b09470f54ef7491000000000000000000000004f",
+        },
+      ],
+    },
+  },
+]
+
+const splitPermissions: Permission[] = [
+  {
+    targetAddress: "0x2086f52651837600180de173b09470f54ef74910",
+    selector: "0x095ea7b3",
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x00000000000000000000000098ef32edd24e2c92525e59afc4475c1242a30184",
+        },
+        {
+          paramType: 1,
+          operator: 0,
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x98ef32edd24e2c92525e59afc4475c1242a30184",
+    selector: "0x43a0d066",
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x000000000000000000000000000000000000000000000000000000000000000a",
+        },
+        {
+          paramType: 1,
+          operator: 0,
+        },
+        {
+          paramType: 1,
+          operator: 0,
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x0821ed041620b83b306ffac74df3fa855cede51a",
+    selector: "0xc32e7202",
+  },
+  {
+    targetAddress: "0x0821ed041620b83b306ffac74df3fa855cede51a",
+    selector: "0x3d18b912",
+  },
+  {
+    targetAddress: "0x0821ed041620b83b306ffac74df3fa855cede51a",
+    selector: "0x7050ccd9",
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 15,
+        },
+        {
+          paramType: 1,
+          operator: 0,
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x2086f52651837600180de173b09470f54ef74910",
+    selector: "0x095ea7b3",
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x0000000000000000000000000fec3d212bcc29ef3e505b555d7a7343df0b7f76",
+        },
+        {
+          paramType: 1,
+          operator: 0,
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x4ecaba5870353805a9f068101a40e0f32ed605c6",
+    selector: "0x095ea7b3",
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x0000000000000000000000000fec3d212bcc29ef3e505b555d7a7343df0b7f76",
+        },
+        {
+          paramType: 1,
+          operator: 0,
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+    selector: "0x095ea7b3",
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x0000000000000000000000000fec3d212bcc29ef3e505b555d7a7343df0b7f76",
+        },
+        {
+          paramType: 1,
+          operator: 0,
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
+    selector: "0x095ea7b3",
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x0000000000000000000000000fec3d212bcc29ef3e505b555d7a7343df0b7f76",
+        },
+        {
+          paramType: 1,
+          operator: 0,
+        },
+      ],
+    },
+  },
+  {
+    targetAddress: "0x0fec3d212bcc29ef3e505b555d7a7343df0b7f76",
+    selector: "0x9eba6619",
+    condition: {
+      paramType: 5,
+      operator: 5,
+      children: [
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x0000000000000000000000000821ed041620b83b306ffac74df3fa855cede51a",
+        },
+        {
+          paramType: 0,
+          operator: 2,
+          children: [
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x0000000000000000000000002086f52651837600180de173b09470f54ef74910",
+            },
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x0000000000000000000000004ecaba5870353805a9f068101a40e0f32ed605c6",
+            },
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x000000000000000000000000ddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+            },
+            {
+              paramType: 1,
+              operator: 16,
+              compValue:
+                "0x000000000000000000000000e91d153e0b41518a2ce8dd3d7944fa863463a97d",
+            },
+          ],
+        },
+        {
+          paramType: 1,
+          operator: 0,
+        },
+        {
+          paramType: 1,
+          operator: 16,
+          compValue:
+            "0x2086f52651837600180de173b09470f54ef7491000000000000000000000004f",
+        },
+        {
+          paramType: 3,
+          operator: 0,
+          children: [
+            {
+              paramType: 4,
+              operator: 0,
+              children: [
+                {
+                  paramType: 1,
+                  operator: 0,
+                },
+              ],
+            },
+            {
+              paramType: 4,
+              operator: 0,
+              children: [
+                {
+                  paramType: 1,
+                  operator: 0,
+                },
+              ],
+            },
+            {
+              paramType: 2,
+              operator: 0,
+            },
+            {
+              paramType: 1,
+              operator: 0,
+            },
+          ],
+        },
+      ],
+    },
+  },
+] as const


### PR DESCRIPTION
Fixes the error at https://roles.gnosisguild.org/permissions/gno/NG5a7BqwydNJYRsXMbc1DbfcwtHBzoefTlnjkgohM

Exposes a new `splitTargets` util function in the SDK.