### PR TITLE
prevent pagination of arrays in subgraph queries

### DIFF
--- a/packages/deployments/src/fetchRole.ts
+++ b/packages/deployments/src/fetchRole.ts
@@ -18,16 +18,16 @@ const QUERY = `
 query Role($id: String) {
   role(id: $id) {
     key
-    members {
+    members(first: 1000) {
       member {
         address
       }
     }
-    targets {
+    targets(first: 1000) {
       address
       clearance
       executionOptions
-      functions {
+      functions(first: 1000) {
         selector
         executionOptions
         wildcarded
@@ -37,7 +37,7 @@ query Role($id: String) {
         }
       }
     }
-    annotations {
+    annotations(first: 1000) {
       uri
       schema
     }
@@ -77,6 +77,10 @@ export const fetchRole = async (
     return null
   }
 
+  assertNoPagination(data.role.members)
+  assertNoPagination(data.role.targets)
+  assertNoPagination(data.role.annotations)
+
   return mapGraphQl(data.role)
 }
 
@@ -105,3 +109,9 @@ const mapGraphQl = (role: any): Role => ({
     })
   ),
 })
+
+const assertNoPagination = (data: any[]) => {
+  if (data.length === 1000) {
+    throw new Error("Pagination not supported")
+  }
+}

--- a/packages/deployments/src/fetchRolesMod.ts
+++ b/packages/deployments/src/fetchRolesMod.ts
@@ -13,18 +13,18 @@ const QUERY = `
       owner
       avatar
       target 
-      roles {
+      roles(first: 1000) {
         key
-        members {
+        members(first: 1000) {
           member {
             address
           }
         }
-        targets {
+        targets(first: 1000) {
           address
           clearance
           executionOptions
-          functions {
+          functions(first: 1000) {
             selector
             wildcarded
             executionOptions
@@ -65,6 +65,12 @@ export const fetchRolesMod = async (
 
   if (!data || !data.rolesModifier) {
     return null
+  }
+
+  assertNoPagination(data.rolesModifier.roles)
+  for (const role of data.rolesModifier.roles) {
+    assertNoPagination(role.members)
+    assertNoPagination(role.targets)
   }
 
   return mapGraphQl(data.rolesModifier)
@@ -134,3 +140,9 @@ const mapGraphQlRole = (role: any): RoleSummary => ({
       })
     ),
 })
+
+const assertNoPagination = (data: any[]) => {
+  if (data.length === 1000) {
+    throw new Error("Pagination not supported")
+  }
+}


### PR DESCRIPTION
the problem manifested itself as incomplete permission lists

we now support a maximum of 999 targets. (1000 is the maximum page size supported by subgraph) the app will now throw an error if a role has more. (this is just a quick fix and we need to implement proper paginated fetching sooner or later)