### PR TITLE
Fix role's `lastUpdate` in subgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,17 +88,17 @@ Address: `0x91B1bd7BCC5E623d5CE76b0152253499a9C819d1`
 
 #### Subgraphs
 
-- [Mainnet](https://api.studio.thegraph.com/query/23167/zodiac-roles-mainnet/v2.3.0)
-- [Optimism](https://api.studio.thegraph.com/query/23167/zodiac-roles-optimism/v2.3.0)
-- [Gnosis](https://api.studio.thegraph.com/query/23167/zodiac-roles-gnosis/v2.3.0)
-- [Polygon](https://api.studio.thegraph.com/query/23167/zodiac-roles-polygon/v2.3.0)
-- [Polygon zkEVM](https://api.studio.thegraph.com/query/23167/zodiac-roles-zkevm/v2.3.0)
-- [Arbitrum One](https://api.studio.thegraph.com/query/23167/zodiac-roles-arbitrum-one/v2.3.0)
-- [Avalanche C-Chain](https://api.studio.thegraph.com/query/23167/zodiac-roles-avalanche/v2.3.0)
-- [BSC](https://api.studio.thegraph.com/query/23167/zodiac-roles-bsc/v2.3.0)
-- [Base](https://api.studio.thegraph.com/query/23167/zodiac-roles-base/v2.3.0)
-- [Base Sepolia](https://api.studio.thegraph.com/query/23167/zodiac-roles-base-sepolia/v2.3.0)
-- [Sepolia](https://api.studio.thegraph.com/query/23167/zodiac-roles-sepolia/v2.3.0)
+- [Mainnet](https://api.studio.thegraph.com/query/23167/zodiac-roles-mainnet/v2.3.1)
+- [Optimism](https://api.studio.thegraph.com/query/23167/zodiac-roles-optimism/v2.3.1)
+- [Gnosis](https://api.studio.thegraph.com/query/23167/zodiac-roles-gnosis/v2.3.1)
+- [Polygon](https://api.studio.thegraph.com/query/23167/zodiac-roles-polygon/v2.3.1)
+- [Polygon zkEVM](https://api.studio.thegraph.com/query/23167/zodiac-roles-zkevm/v2.3.1)
+- [Arbitrum One](https://api.studio.thegraph.com/query/23167/zodiac-roles-arbitrum-one/v2.3.1)
+- [Avalanche C-Chain](https://api.studio.thegraph.com/query/23167/zodiac-roles-avalanche/v2.3.1)
+- [BSC](https://api.studio.thegraph.com/query/23167/zodiac-roles-bsc/v2.3.1)
+- [Base](https://api.studio.thegraph.com/query/23167/zodiac-roles-base/v2.3.1)
+- [Base Sepolia](https://api.studio.thegraph.com/query/23167/zodiac-roles-base-sepolia/v2.3.1)
+- [Sepolia](https://api.studio.thegraph.com/query/23167/zodiac-roles-sepolia/v2.3.1)
 
 ### Development environment setup
 

--- a/packages/deployments/package.json
+++ b/packages/deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodiac-roles-deployments",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "license": "LGPL-3.0+",
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",

--- a/packages/deployments/src/chains.ts
+++ b/packages/deployments/src/chains.ts
@@ -3,66 +3,66 @@ export const chains = {
     name: "mainnet",
     prefix: "eth",
     subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-mainnet/v2.3.0",
+      "https://api.studio.thegraph.com/query/93263/zodiac-roles-mainnet/v2.3.1",
   },
   [10]: {
     name: "optimism",
     prefix: "oeth",
     subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-optimism/v2.3.0",
+      "https://api.studio.thegraph.com/query/93263/zodiac-roles-optimism/v2.3.1",
   },
   [100]: {
     name: "gnosis",
     prefix: "gno",
     subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-gnosis/v2.3.0",
+      "https://api.studio.thegraph.com/query/93263/zodiac-roles-gnosis/v2.3.1",
   },
   [137]: {
     name: "polygon",
     prefix: "matic",
     subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-polygon/v2.3.0",
+      "https://api.studio.thegraph.com/query/93263/zodiac-roles-polygon/v2.3.1",
   },
   [1101]: {
     name: "zkevm",
     prefix: "zkevm",
     subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-zkevm/v2.3.0",
+      "https://api.studio.thegraph.com/query/93263/zodiac-roles-zkevm/v2.3.1",
   },
   [42161]: {
     name: "arbitrumOne",
     prefix: "arb1",
     subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-arbitrum-one/v2.3.0",
+      "https://api.studio.thegraph.com/query/93263/zodiac-roles-arbitrum-one/v2.3.1",
   },
   [43114]: {
     name: "avalanche",
     prefix: "avax",
     subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-avalanche/v2.3.0",
+      "https://api.studio.thegraph.com/query/93263/zodiac-roles-avalanche/v2.3.1",
   },
   [56]: {
     name: "bsc",
     prefix: "bnb",
     subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-bsc/v2.3.0",
+      "https://api.studio.thegraph.com/query/93263/zodiac-roles-bsc/v2.3.1",
   },
   [8453]: {
     name: "base",
     prefix: "base",
     subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-base/v2.3.0",
+      "https://api.studio.thegraph.com/query/93263/zodiac-roles-base/v2.3.1",
   },
   [84532]: {
     name: "baseSepolia",
     prefix: "basesep",
     subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-base-sepolia/v2.3.0",
+      "https://api.studio.thegraph.com/query/93263/zodiac-roles-base-sepolia/v2.3.1",
   },
   [11155111]: {
     name: "sepolia",
     prefix: "sep",
     subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-sepolia/v2.3.0",
+      "https://api.studio.thegraph.com/query/93263/zodiac-roles-sepolia/v2.3.1",
   },
 } as const


### PR DESCRIPTION
fixes an issue where the role's `lastUpdate` field is not updated for changes to annotations.

- [x] bump patch of zodiac-roles-deployments
- [x] wait until the new subgraph versions are fully indexed
- [x] publish zodiac-roles-deployments