### PR TITLE
Use production subgraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,17 +88,17 @@ Address: `0x91B1bd7BCC5E623d5CE76b0152253499a9C819d1`
 
 #### Subgraphs
 
-- [Mainnet](https://api.studio.thegraph.com/query/23167/zodiac-roles-mainnet/v2.3.4)
-- [Optimism](https://api.studio.thegraph.com/query/23167/zodiac-roles-optimism/v2.3.4)
-- [Gnosis](https://api.studio.thegraph.com/query/23167/zodiac-roles-gnosis/v2.3.4)
-- [Polygon](https://api.studio.thegraph.com/query/23167/zodiac-roles-polygon/v2.3.4)
-- [Polygon zkEVM](https://api.studio.thegraph.com/query/23167/zodiac-roles-zkevm/v2.3.4)
-- [Arbitrum One](https://api.studio.thegraph.com/query/23167/zodiac-roles-arbitrum-one/v2.3.4)
-- [Avalanche C-Chain](https://api.studio.thegraph.com/query/23167/zodiac-roles-avalanche/v2.3.4)
-- [BSC](https://api.studio.thegraph.com/query/23167/zodiac-roles-bsc/v2.3.4)
-- [Base](https://api.studio.thegraph.com/query/23167/zodiac-roles-base/v2.3.4)
-- [Base Sepolia](https://api.studio.thegraph.com/query/23167/zodiac-roles-base-sepolia/v2.3.4)
-- [Sepolia](https://api.studio.thegraph.com/query/23167/zodiac-roles-sepolia/v2.3.4)
+- [Mainnet](https://api.studio.thegraph.com/query/93263/zodiac-roles-mainnet/version/latest)
+- [Optimism](https://api.studio.thegraph.com/query/93263/zodiac-roles-optimism/version/latest)
+- [Gnosis](https://api.studio.thegraph.com/query/93263/zodiac-roles-gnosis/version/latest)
+- [Polygon](https://api.studio.thegraph.com/query/93263/zodiac-roles-polygon/version/latest)
+- [Polygon zkEVM](https://api.studio.thegraph.com/query/93263/zodiac-roles-zkevm/version/latest)
+- [Arbitrum One](https://api.studio.thegraph.com/query/93263/zodiac-roles-arbitrum-one/version/latest)
+- [Avalanche C-Chain](https://api.studio.thegraph.com/query/93263/zodiac-roles-avalanche/version/latest)
+- [BSC](https://api.studio.thegraph.com/query/93263/zodiac-roles-bsc/version/latest)
+- [Base](https://api.studio.thegraph.com/query/93263/zodiac-roles-base/version/latest)
+- [Base Sepolia](https://api.studio.thegraph.com/query/93263/zodiac-roles-base-sepolia/version/latest)
+- [Sepolia](https://api.studio.thegraph.com/query/93263/zodiac-roles-sepolia/version/latest)
 
 ### Development environment setup
 

--- a/packages/deployments/src/chains.ts
+++ b/packages/deployments/src/chains.ts
@@ -7,71 +7,51 @@ export const chains = {
   [10]: {
     name: "optimism",
     prefix: "oeth",
-    subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-optimism/v2.3.4",
-    subgraphDeploymentId: "Q...",
+    subgraphDeploymentId: "QmeJXG1sWpdbqs4nZE9JFs2j9nGuFLH4VCmbCVXP7oQh9d",
   },
   [100]: {
     name: "gnosis",
     prefix: "gno",
-    subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-gnosis/v2.3.4",
     subgraphDeploymentId: "QmR1TkpcQzhBfUwmRJfeV4kQbUbDUZUvyWxtLTCYkiivvz",
   },
   [137]: {
     name: "polygon",
     prefix: "matic",
-    subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-polygon/v2.3.4",
-    subgraphDeploymentId: "Q...",
+    subgraphDeploymentId: "QmVrtFGzKJcuCbdbeaCAmhzJeVpkqrySNwvaCiVSpip4cm",
   },
   [1101]: {
     name: "zkevm",
     prefix: "zkevm",
-    subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-zkevm/v2.3.4",
-    subgraphDeploymentId: "Q...",
+    subgraphDeploymentId: "QmctRf4gwTT63t2SNT4pFekHfjjHyV97jX8CaMQdrUBS4y",
   },
   [42161]: {
     name: "arbitrumOne",
     prefix: "arb1",
-    subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-arbitrum-one/v2.3.4",
-    subgraphDeploymentId: "Q...",
+    subgraphDeploymentId: "QmPBUT8onznz5kocjwzzQPoRatu8gSPAaaSra7jixaF1mD",
   },
   [43114]: {
     name: "avalanche",
     prefix: "avax",
-    subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-avalanche/v2.3.4",
-    subgraphDeploymentId: "Q...",
+    subgraphDeploymentId: "QmSegJhx8SEQ5WFfi6ZLQLs8XRSfLoka7yULsUKgeGBLnT",
   },
   [56]: {
     name: "bsc",
     prefix: "bnb",
-    subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-bsc/v2.3.4",
-    subgraphDeploymentId: "Q...",
+    subgraphDeploymentId: "QmUM9dfkiN5jHMxUzPYHW8tKguPr65qnWpzb3dRMKT1kDc",
   },
   [8453]: {
     name: "base",
     prefix: "base",
-    subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-base/v2.3.4",
-    subgraphDeploymentId: "Q...",
+    subgraphDeploymentId: "QmWGQfg86sAjZUQ2HUeHN4mVQTejFb1XPPtLLoz2Ks7Wfp",
   },
   [84532]: {
     name: "baseSepolia",
     prefix: "basesep",
-    subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-base-sepolia/v2.3.4",
-    subgraphDeploymentId: "Q...",
+    subgraphDeploymentId: "QmSZuUNsMtLjN9Gd4sNu7rCGChZ56NQc2XY7kN3YLz9pQD",
   },
   [11155111]: {
     name: "sepolia",
     prefix: "sep",
-    subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-sepolia/v2.3.4",
-    subgraphDeploymentId: "Q...",
+    subgraphDeploymentId: "QmdeXJ7g889wK4wDNpRrvKGN91SZiwvdmCU9dFQsgqaQ3K",
   },
 } as const

--- a/packages/deployments/src/chains.ts
+++ b/packages/deployments/src/chains.ts
@@ -2,67 +2,76 @@ export const chains = {
   [1]: {
     name: "mainnet",
     prefix: "eth",
-    subgraph:
-      "https://api.studio.thegraph.com/query/93263/zodiac-roles-mainnet/v2.3.4",
+    subgraphDeploymentId: "QmSXFnZr641zZforeXRAGHfynCEi1Vq35AKQ8qB1W1CdU6",
   },
   [10]: {
     name: "optimism",
     prefix: "oeth",
     subgraph:
       "https://api.studio.thegraph.com/query/93263/zodiac-roles-optimism/v2.3.4",
+    subgraphDeploymentId: "Q...",
   },
   [100]: {
     name: "gnosis",
     prefix: "gno",
     subgraph:
       "https://api.studio.thegraph.com/query/93263/zodiac-roles-gnosis/v2.3.4",
+    subgraphDeploymentId: "QmR1TkpcQzhBfUwmRJfeV4kQbUbDUZUvyWxtLTCYkiivvz",
   },
   [137]: {
     name: "polygon",
     prefix: "matic",
     subgraph:
       "https://api.studio.thegraph.com/query/93263/zodiac-roles-polygon/v2.3.4",
+    subgraphDeploymentId: "Q...",
   },
   [1101]: {
     name: "zkevm",
     prefix: "zkevm",
     subgraph:
       "https://api.studio.thegraph.com/query/93263/zodiac-roles-zkevm/v2.3.4",
+    subgraphDeploymentId: "Q...",
   },
   [42161]: {
     name: "arbitrumOne",
     prefix: "arb1",
     subgraph:
       "https://api.studio.thegraph.com/query/93263/zodiac-roles-arbitrum-one/v2.3.4",
+    subgraphDeploymentId: "Q...",
   },
   [43114]: {
     name: "avalanche",
     prefix: "avax",
     subgraph:
       "https://api.studio.thegraph.com/query/93263/zodiac-roles-avalanche/v2.3.4",
+    subgraphDeploymentId: "Q...",
   },
   [56]: {
     name: "bsc",
     prefix: "bnb",
     subgraph:
       "https://api.studio.thegraph.com/query/93263/zodiac-roles-bsc/v2.3.4",
+    subgraphDeploymentId: "Q...",
   },
   [8453]: {
     name: "base",
     prefix: "base",
     subgraph:
       "https://api.studio.thegraph.com/query/93263/zodiac-roles-base/v2.3.4",
+    subgraphDeploymentId: "Q...",
   },
   [84532]: {
     name: "baseSepolia",
     prefix: "basesep",
     subgraph:
       "https://api.studio.thegraph.com/query/93263/zodiac-roles-base-sepolia/v2.3.4",
+    subgraphDeploymentId: "Q...",
   },
   [11155111]: {
     name: "sepolia",
     prefix: "sep",
     subgraph:
       "https://api.studio.thegraph.com/query/93263/zodiac-roles-sepolia/v2.3.4",
+    subgraphDeploymentId: "Q...",
   },
 } as const

--- a/packages/deployments/src/fetchRole.ts
+++ b/packages/deployments/src/fetchRole.ts
@@ -1,4 +1,5 @@
 import { chains } from "./chains"
+import { assertNoPagination, fetchFromSubgraph, FetchOptions } from "./subgraph"
 import {
   ChainId,
   Role,
@@ -15,11 +16,13 @@ type Props = {
   blockNumber?: number
 } & (
   | {
-      /** pass a chainId to use query against a dev subgraph */
+      /** pass a chainId to use query against the official subgraph deployment */
       chainId: ChainId
+      /** pass your own API key from The Graph for production use */
+      theGraphApiKey?: string
     }
   | {
-      /** pass your own subgraph endpoint for production use */
+      /** pass your own subgraph endpoint */
       subgraph: string
     }
 )
@@ -91,43 +94,29 @@ query Role($id: String, $block: Int) {
 const getRoleId = (address: `0x${string}`, roleKey: `0x${string}`) =>
   `${address.toLowerCase()}-ROLE-${roleKey}`
 
-type FetchOptions = Omit<RequestInit, "method" | "body">
-
 export const fetchRole = async (
-  { address, roleKey, blockNumber, ...rest }: Props,
+  { address, roleKey, blockNumber, ...subgraphProps }: Props,
   options?: FetchOptions
 ): Promise<Role | null> => {
-  const endpoint =
-    "subgraph" in rest ? rest.subgraph : chains[rest.chainId].subgraph
-
-  const res = await fetch(endpoint, {
-    ...options,
-    method: "POST",
-    headers: {
-      ...options?.headers,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
+  const { role } = await fetchFromSubgraph(
+    subgraphProps,
+    {
       query: blockNumber ? ROLE_AT_BLOCK_QUERY : ROLE_QUERY,
       variables: { id: getRoleId(address, roleKey), block: blockNumber },
       operationName: "Role",
-    }),
-  })
-  const { data, error, errors } = await res.json()
+    },
+    options
+  )
 
-  if (error || (errors && errors[0])) {
-    throw new Error(error || errors[0])
-  }
-
-  if (!data || !data.role) {
+  if (!role) {
     return null
   }
 
-  assertNoPagination(data.role.members)
-  assertNoPagination(data.role.targets)
-  assertNoPagination(data.role.annotations)
+  assertNoPagination(role.members)
+  assertNoPagination(role.targets)
+  assertNoPagination(role.annotations)
 
-  return mapGraphQl(data.role)
+  return mapGraphQl(role)
 }
 
 const mapGraphQl = (role: any): Role => ({
@@ -155,9 +144,3 @@ const mapGraphQl = (role: any): Role => ({
     })
   ),
 })
-
-const assertNoPagination = (data: any[]) => {
-  if (data.length === 1000) {
-    throw new Error("Pagination not supported")
-  }
-}

--- a/packages/deployments/src/fetchRole.ts
+++ b/packages/deployments/src/fetchRole.ts
@@ -27,9 +27,7 @@ type Props = {
     }
 )
 
-const ROLE_QUERY = `
-query Role($id: String) {
-  role(id: $id) {
+const ROLE_FIELDS = `
     key
     members(first: 1000) {
       member {
@@ -55,6 +53,12 @@ query Role($id: String) {
       schema
     }
     lastUpdate
+`.trim()
+
+const ROLE_QUERY = `
+query Role($id: String) {
+  role(id: $id) {
+    ${ROLE_FIELDS}
   }
 }
 `.trim()
@@ -62,31 +66,7 @@ query Role($id: String) {
 const ROLE_AT_BLOCK_QUERY = `
 query Role($id: String, $block: Int) {
   role(id: $id, block: { number: $block }) {
-    key
-    members(first: 1000) {
-      member {
-        address
-      }
-    }
-    targets(first: 1000) {
-      address
-      clearance
-      executionOptions
-      functions(first: 1000) {
-        selector
-        executionOptions
-        wildcarded
-        condition {
-          id
-          json
-        }
-      }
-    }
-    annotations(first: 1000) {
-      uri
-      schema
-    }
-    lastUpdate
+    ${ROLE_FIELDS}
   }
 }
 `.trim()

--- a/packages/deployments/src/fetchRolesMod.ts
+++ b/packages/deployments/src/fetchRolesMod.ts
@@ -10,6 +10,8 @@ import {
 
 type Props = {
   address: `0x${string}`
+  /** Specify a block height to fetch a historic state of the Roles mod. Defaults to latest block. */
+  blockNumber?: number
 } & (
   | {
       /** pass a chainId to use query against the official subgraph deployment */
@@ -23,61 +25,73 @@ type Props = {
     }
 )
 
-const QUERY = `
-  query RolesMod($id: String) {
-    rolesModifier(id: $id) {
-      address
-      owner
-      avatar
-      target 
-      roles(first: 1000) {
-        key
-        members(first: 1000) {
-          member {
-            address
-          }
-        }
-        targets(first: 1000) {
+const MOD_FIELDS = `
+    address
+    owner
+    avatar
+    target 
+    roles(first: 1000) {
+      key
+      members(first: 1000) {
+        member {
           address
-          clearance
+        }
+      }
+      targets(first: 1000) {
+        address
+        clearance
+        executionOptions
+        functions(first: 1000) {
+          selector
+          wildcarded
           executionOptions
-          functions(first: 1000) {
-            selector
-            wildcarded
-            executionOptions
-          }
         }
-        lastUpdate
       }
-      allowances(first: 1000) {
-        key
-        refill
-        maxRefill
-        period
-        balance
-        timestamp
-      }
-      unwrapAdapters(
-        first: 1000,
-        where: {
-          selector: "0x8d80ff0a", 
-          adapterAddress: "0x93b7fcbc63ed8a3a24b59e1c3e6649d50b7427c0"
-        }
-      ) {
-        targetAddress
-      }
+      lastUpdate
     }
+    allowances(first: 1000) {
+      key
+      refill
+      maxRefill
+      period
+      balance
+      timestamp
+    }
+    unwrapAdapters(
+      first: 1000,
+      where: {
+        selector: "0x8d80ff0a", 
+        adapterAddress: "0x93b7fcbc63ed8a3a24b59e1c3e6649d50b7427c0"
+      }
+    ) {
+      targetAddress
+    }
+`.trim()
+
+const MOD_QUERY = `
+query RolesMod($id: String) {
+  rolesModifier(id: $id) {
+    ${MOD_FIELDS}
   }
+}
+`
+
+const MOD_AT_BLOCK_QUERY = `
+query RolesMod($id: String, $block: Int) {
+  rolesModifier(id: $id, block: { number: $block }) {
+    ${MOD_FIELDS}
+  }
+}
 `
 
 export const fetchRolesMod = async (
-  { address, ...subgraphProps }: Props,
+  { address, blockNumber, ...subgraphProps }: Props,
   options?: FetchOptions
 ): Promise<RolesModifier | null> => {
   const { rolesModifier } = await fetchFromSubgraph(
     subgraphProps,
     {
-      query: QUERY,
+      query: blockNumber ? MOD_AT_BLOCK_QUERY : MOD_QUERY,
       variables: { id: address.toLowerCase() },
       operationName: "RolesMod",
     },
@@ -92,9 +106,10 @@ export const fetchRolesMod = async (
   for (const role of rolesModifier.roles) {
     assertNoPagination(role.members)
     assertNoPagination(role.targets)
-    assertNoPagination(role.allowances)
-    assertNoPagination(role.unwrapAdapters)
   }
+
+  assertNoPagination(rolesModifier.allowances)
+  assertNoPagination(rolesModifier.unwrapAdapters)
 
   return mapGraphQl(rolesModifier)
 }

--- a/packages/deployments/src/fetchRolesMod.ts
+++ b/packages/deployments/src/fetchRolesMod.ts
@@ -92,7 +92,7 @@ export const fetchRolesMod = async (
     subgraphProps,
     {
       query: blockNumber ? MOD_AT_BLOCK_QUERY : MOD_QUERY,
-      variables: { id: address.toLowerCase() },
+      variables: { id: address.toLowerCase(), block: blockNumber },
       operationName: "RolesMod",
     },
     options

--- a/packages/deployments/src/subgraph.ts
+++ b/packages/deployments/src/subgraph.ts
@@ -50,8 +50,6 @@ export const fetchFromSubgraph = async (
 
   const { data, error, errors } = await res.json()
 
-  console.log(data, error, errors)
-
   const foundError = error || (errors && errors[0])
   if (foundError) {
     const message =
@@ -62,7 +60,7 @@ export const fetchFromSubgraph = async (
   }
 
   if (!data) {
-    throw new Error("subgraph query returned no data")
+    throw new Error("Subgraph query returned no data")
   }
 
   return data

--- a/packages/deployments/src/subgraph.ts
+++ b/packages/deployments/src/subgraph.ts
@@ -1,0 +1,80 @@
+import { chains } from "./chains"
+import { ChainId } from "./types"
+
+export type FetchOptions = Omit<RequestInit, "method" | "body">
+
+interface QueryRequest {
+  query: string
+  variables: { [key: string]: string | number | undefined }
+  operationName: string
+}
+
+type EndpointConfig =
+  | {
+      subgraph: string
+    }
+  | { chainId: ChainId; theGraphApiKey?: string }
+
+// This is an API key owner by Gnosis Guild. It has a low monthly quota and should only be used for development purposes.
+const DEV_API_KEY = "ea04dbe51a8de70fb8afccc3c9bccac7"
+
+const resolveEndpointUrl = (endpoint: EndpointConfig) => {
+  if ("subgraph" in endpoint && endpoint.subgraph != null) {
+    return endpoint.subgraph
+  }
+
+  if (!("chainId" in endpoint)) {
+    throw new Error("provide either a subgraph or a chainId")
+  }
+
+  const apiKey = endpoint.theGraphApiKey ?? DEV_API_KEY
+  const { subgraphDeploymentId } = chains[endpoint.chainId]
+
+  return `https://gateway.thegraph.com/api/${apiKey}/deployments/id/${subgraphDeploymentId}`
+}
+
+export const fetchFromSubgraph = async (
+  endpoint: EndpointConfig,
+  request: QueryRequest,
+  options?: FetchOptions
+) => {
+  const res = await fetch(resolveEndpointUrl(endpoint), {
+    ...options,
+    method: "POST",
+    headers: {
+      ...options?.headers,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(request),
+  })
+
+  const { data, error, errors } = await res.json()
+
+  console.log(data, error, errors)
+
+  const foundError = error || (errors && errors[0])
+  if (foundError) {
+    const message =
+      typeof foundError === "object"
+        ? foundError.message || "Unknown error"
+        : foundError
+    throw new Error(message)
+  }
+
+  if (!data) {
+    throw new Error("subgraph query returned no data")
+  }
+
+  return data
+}
+
+/**
+ * Subgraph has a maximum page size of 1000, which we're setting in our queries.
+ * If there are 1000 results, it's likely there are more and for now we throw an error in that case.
+ * This is to prevent people from inadvertently working with incomplete representations.
+ **/
+export const assertNoPagination = (data: any[]) => {
+  if (data.length === 1000) {
+    throw new Error("Pagination not supported")
+  }
+}

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -21,6 +21,7 @@
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "chai": "^4.3.10",
+    "chai-as-promised": "^7.1.2",
     "eslint": "^8.53.0",
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/packages/integration-tests/test/fetchRole.test.ts
+++ b/packages/integration-tests/test/fetchRole.test.ts
@@ -1,7 +1,11 @@
-import { expect } from "chai"
+import chai from "chai"
+import chaiAsPromised from "chai-as-promised"
 import { fetchRole } from "zodiac-roles-deployments"
 
-describe("fetchRole", () => {
+chai.use(chaiAsPromised)
+const expect = chai.expect
+
+describe.only("fetchRole", () => {
   it("allows fetching historic role states", async () => {
     const role = await fetchRole({
       address: "0x13c61a25db73e7a94a244bd2205adba8b4a60f4a",
@@ -17,5 +21,19 @@ describe("fetchRole", () => {
       annotations: [],
       lastUpdate: "19790837",
     })
+  })
+
+  it("handles errors when passing invalid parameters", async () => {
+    await expect(
+      fetchRole({
+        address: "0x13c61a25db73e7a94a244bd2205adba8b4a60f4a",
+        chainId: 100,
+        roleKey:
+          "0x4d414e4147455200000000000000000000000000000000000000000000000000",
+        blockNumber: 19790837,
+      })
+    ).to.be.rejectedWith(
+      "bad query: bad query: requested block 19790837, before minimum `startBlock` of manifest 31222929"
+    )
   })
 })

--- a/packages/integration-tests/test/fetchRole.test.ts
+++ b/packages/integration-tests/test/fetchRole.test.ts
@@ -5,7 +5,7 @@ import { fetchRole } from "zodiac-roles-deployments"
 chai.use(chaiAsPromised)
 const expect = chai.expect
 
-describe.only("fetchRole", () => {
+describe("fetchRole", () => {
   it("allows fetching historic role states", async () => {
     const role = await fetchRole({
       address: "0x13c61a25db73e7a94a244bd2205adba8b4a60f4a",

--- a/packages/integration-tests/test/fetchRolesMod.test.ts
+++ b/packages/integration-tests/test/fetchRolesMod.test.ts
@@ -1,0 +1,45 @@
+import chai from "chai"
+import chaiAsPromised from "chai-as-promised"
+import { fetchRolesMod } from "zodiac-roles-deployments"
+
+chai.use(chaiAsPromised)
+const expect = chai.expect
+
+describe.only("fetchRolesMod", () => {
+  it("fetches the mod's base config, allowance, and unwrap adapter", async () => {
+    const rolesMod = await fetchRolesMod({
+      address: "0x13c61a25db73e7a94a244bd2205adba8b4a60f4a",
+      chainId: 1,
+      blockNumber: 21739074,
+    })
+    expect(rolesMod).to.have.property(
+      "address",
+      "0x13c61a25db73e7a94a244bd2205adba8b4a60f4a"
+    )
+    expect(rolesMod).to.have.property("owner")
+    expect(rolesMod).to.have.property("avatar")
+    expect(rolesMod).to.have.property("target")
+    expect(rolesMod).to.have.property("allowances")
+    expect(rolesMod).to.have.property("unwrapAdapters")
+  })
+
+  it("fetches all roles but omits conditions while indicating if the target function is wildcarded", async () => {
+    const rolesMod = await fetchRolesMod({
+      address: "0x13c61a25db73e7a94a244bd2205adba8b4a60f4a",
+      chainId: 1,
+      blockNumber: 21739074,
+    })
+
+    if (!rolesMod) throw new Error("rolesMod is null")
+
+    expect(rolesMod).to.have.property("roles")
+    const firstRole = rolesMod.roles[0]
+    expect(firstRole).to.have.property("key")
+    expect(firstRole).to.have.property("members")
+    expect(firstRole).to.have.property("targets")
+
+    const funcWithCondition = firstRole.targets[1].functions[0]
+    expect(funcWithCondition).to.have.property("wildcarded", false)
+    expect(funcWithCondition).to.not.have.property("condition")
+  })
+})

--- a/packages/integration-tests/test/fetchRolesMod.test.ts
+++ b/packages/integration-tests/test/fetchRolesMod.test.ts
@@ -5,7 +5,7 @@ import { fetchRolesMod } from "zodiac-roles-deployments"
 chai.use(chaiAsPromised)
 const expect = chai.expect
 
-describe.only("fetchRolesMod", () => {
+describe("fetchRolesMod", () => {
   it("fetches the mod's base config, allowance, and unwrap adapter", async () => {
     const rolesMod = await fetchRolesMod({
       address: "0x13c61a25db73e7a94a244bd2205adba8b4a60f4a",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6495,7 +6495,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai-as-promised@npm:^7.1.1":
+"chai-as-promised@npm:^7.1.1, chai-as-promised@npm:^7.1.2":
   version: 7.1.2
   resolution: "chai-as-promised@npm:7.1.2"
   dependencies:
@@ -20415,6 +20415,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.62.0
     "@typescript-eslint/parser": ^5.62.0
     chai: ^4.3.10
+    chai-as-promised: ^7.1.2
     eslint: ^8.53.0
     eslint-config-prettier: ^8.10.0
     eslint-plugin-prettier: ^4.2.1


### PR DESCRIPTION
With this PR we start using production endpoints for our now published subgraphs. So far we have been querying from dev endpoints and subgraph recently started archiving deployments older than the last 2, which made this switch somewhat urgent.

By default queries will use a The Graph API key owned by GG with low quota. Users can set their own API keys and should do so for production use.

BREAKING CHANGE: the exported `chains` config no longer contains subgraph URLs, but subgraph deployment IDs instead.