### PR TITLE
feat: introduce lisk sepolia

### DIFF
--- a/packages/evm/hardhat.config.ts
+++ b/packages/evm/hardhat.config.ts
@@ -124,6 +124,12 @@ const config: HardhatUserConfig = {
       chainId: 84532,
       url: `https://sepolia.base.org`,
     },
+    "lisk-sepolia": {
+      ...sharedNetworkConfig,
+      chainId: 4202,
+      url: "https://rpc.sepolia-api.lisk.com",
+      gasPrice: 1000000000,
+    },
   },
   etherscan: {
     apiKey: {
@@ -138,6 +144,8 @@ const config: HardhatUserConfig = {
       base: BASESCAN_API_KEY,
       baseSepolia: BASESCAN_API_KEY,
       bsc: BSCSCAN_API_KEY,
+      // Use "ETHERSCAN_API_KEY" as a placeholder, because Blockscout doesn't need a real API key, and Hardhat will complain if this property isn't set.
+      "lisk-sepolia": ETHERSCAN_API_KEY,
     } as Record<string, string>,
     customChains: [
       {
@@ -196,7 +204,18 @@ const config: HardhatUserConfig = {
           browserURL: "https://bscscan.com",
         },
       },
+      {
+        network: "lisk-sepolia",
+        chainId: 4202,
+        urls: {
+          apiURL: "https://sepolia-blockscout.lisk.com/api",
+          browserURL: "https://sepolia-blockscout.lisk.com",
+        },
+      },
     ],
+  },
+  sourcify: {
+    enabled: false,
   },
   gasReporter: {
     enabled: true,


### PR DESCRIPTION
## **Description:**

This PR adds support for the **Lisk Sepolia** testnet in Hardhat configuration. The newly introduced network allows deploying and verifying smart contracts on Lisk's Sepolia blockchain.

### Changes:
- Added `lisk-sepolia` network configuration to `hardhat.config.ts`.
- Included `lisk-sepolia` under the `etherscan.apiKey` configuration using a placeholder key.
- Extended `customChains` configuration to support contract verification for Lisk Sepolia.

### Deployment and Verification:
The following contracts were successfully deployed on **Lisk Sepolia**:

- **AvatarIsOwnerOfERC721@2.1.0**: [0x91B1bd7BCC5E623d5CE76b0152253499a9C819d1](https://sepolia-blockscout.lisk.com/address/0x91B1bd7BCC5E623d5CE76b0152253499a9C819d1?tab=contract)
- **Integrity@2.1.0**: [0x6a6Af4b16458Bc39817e4019fB02BD3b26d41049](https://sepolia-blockscout.lisk.com/address/0x6a6Af4b16458Bc39817e4019fB02BD3b26d41049?tab=contract)
- **Packer@2.1.0**: [0x61C5B1bE435391fDd7BC6703F3740C0d11728a8C](https://sepolia-blockscout.lisk.com/address/0x61C5B1bE435391fDd7BC6703F3740C0d11728a8C?tab=contract)
- **Roles@2.1.0**: [0x9646fDAD06d3e24444381f44362a3B0eB343D337](https://sepolia-blockscout.lisk.com/address/0x9646fDAD06d3e24444381f44362a3B0eB343D337?tab=contract)
- **MultiSendUnwrapper@2.1.0**: [0x93B7fCbc63ED8a3a24B59e1C3e6649D50B7427c0](https://sepolia-blockscout.lisk.com/address/0x93B7fCbc63ED8a3a24B59e1C3e6649D50B7427c0?tab=contract)

### Verification Issues and Solution:
While verifying the **Roles** contract, an issue arose when using the standard Hardhat verification process. The verification failed due to inconsistencies in the default Hardhat plugin.

To resolve this, **Forge** was used for verification, and the following command successfully verified the contract:

```bash
forge verify-contract \
  --rpc-url https://rpc.sepolia-api.lisk.com \
  --verifier blockscout \
  --verifier-url 'https://sepolia-blockscout.lisk.com/api' \
  --compiler-version 0.8.21 \
  --root packages/evm \
  0x9646fDAD06d3e24444381f44362a3B0eB343D337 \
  contracts/Roles.sol:Roles
```

Verification response:
```
Submitted contract for verification:
        Response: `OK`
        GUID: `9646fdad06d3e24444381f44362a3b0eb343d33767a38919`
        URL: https://sepolia-blockscout.lisk.com/address/0x9646fdad06d3e24444381f44362a3b0eb343d337
```

This issue has been documented to ensure a smooth verification process for future deployments on **Lisk Sepolia**.

### References:
- Official Lisk documentation: [Deploying Smart Contracts with Hardhat](https://docs.lisk.com/building-on-lisk/deploying-smart-contract/with-Hardhat)
