### PR TITLE
fix allowance condition helpers

### DIFF
--- a/packages/docs/content/sdk/conditions.mdx
+++ b/packages/docs/content/sdk/conditions.mdx
@@ -140,13 +140,21 @@ c.calldataMatches(
 
 See [`WithinAllowance`](/general/conditions#withinallowance) operator
 
-#### `c.etherWithinAllowance`
+#### Allowance on Ether value via `c.calldataMatches`
 
-See [`EtherWithinAllowance`](/general/conditions#etherwithinallowance) operator
+```typescript
+c.calldataMatches([], [], {
+  etherWithinAllowance: encodeKey("mt-eth-allowance"),
+});
+```
 
-#### `c.callWithinAllowance`
+#### Allowance on call rate via `c.calldataMatches`
 
-See [`CallWithinAllowance`](/general/conditions#callwithinallowance) operator
+```typescript
+c.calldataMatches([], [], {
+  callWithinAllowance: encodeKey("my-call-allowance"),
+});
+```
 
 ### Custom conditions
 

--- a/packages/sdk/src/main/target/authoring/c/allowances.ts
+++ b/packages/sdk/src/main/target/authoring/c/allowances.ts
@@ -18,19 +18,3 @@ export const withinAllowance =
       compValue: abiEncode(["bytes32"], [allowanceKey]) as `0x${string}`,
     }
   }
-
-export const callWithinAllowance = (allowanceKey: `0x${string}`) => () => {
-  return {
-    paramType: ParameterType.None,
-    operator: Operator.CallWithinAllowance,
-    compValue: abiEncode(["bytes32"], [allowanceKey]) as `0x${string}`,
-  }
-}
-
-export const etherWithinAllowance = (allowanceKey: `0x${string}`) => () => {
-  return {
-    paramType: ParameterType.None,
-    operator: Operator.EtherWithinAllowance,
-    compValue: abiEncode(["bytes32"], [allowanceKey]) as `0x${string}`,
-  }
-}

--- a/packages/sdk/src/main/target/authoring/c/matches.test.ts
+++ b/packages/sdk/src/main/target/authoring/c/matches.test.ts
@@ -5,7 +5,7 @@ import { calldataMatches } from "./matches"
 import { encodeKey } from "../../../keys"
 
 describe("calldataMatches", () => {
-  it("correctly encodes etherWithinAllowance conditions", () => {
+  it("correctly encodes EtherWithinAllowance conditions", () => {
     const result = calldataMatches([], [], {
       etherWithinAllowance: encodeKey("test-allowance"),
     })()

--- a/packages/sdk/src/main/target/authoring/c/matches.test.ts
+++ b/packages/sdk/src/main/target/authoring/c/matches.test.ts
@@ -2,15 +2,13 @@ import { describe, expect, it } from "vitest"
 import { Operator, ParameterType } from "zodiac-roles-deployments"
 
 import { calldataMatches } from "./matches"
-import { etherWithinAllowance } from "./allowances"
 import { encodeKey } from "../../../keys"
 
 describe("calldataMatches", () => {
-  it("creates the correct structure for etherWithinAllowance", () => {
-    const result = calldataMatches(
-      [etherWithinAllowance(encodeKey("test-allowance"))],
-      []
-    )()
+  it("correctly encodes etherWithinAllowance conditions", () => {
+    const result = calldataMatches([], [], {
+      etherWithinAllowance: encodeKey("test-allowance"),
+    })()
 
     expect(result).toEqual({
       paramType: ParameterType.Calldata,

--- a/packages/sdk/src/main/target/authoring/c/matches.test.ts
+++ b/packages/sdk/src/main/target/authoring/c/matches.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { Operator, ParameterType } from "zodiac-roles-deployments"
+
+import { calldataMatches } from "./matches"
+import { etherWithinAllowance } from "./allowances"
+import { encodeKey } from "../../../keys"
+
+describe("calldataMatches", () => {
+  it("creates the correct structure for etherWithinAllowance", () => {
+    const result = calldataMatches(
+      [etherWithinAllowance(encodeKey("test-allowance"))],
+      []
+    )()
+
+    expect(result).toEqual({
+      paramType: ParameterType.Calldata,
+      operator: Operator.Matches,
+      children: [
+        {
+          paramType: ParameterType.None,
+          operator: Operator.EtherWithinAllowance,
+          compValue: encodeKey("test-allowance"),
+        },
+      ],
+    })
+  })
+})

--- a/packages/sdk/src/main/target/authoring/c/matches.ts
+++ b/packages/sdk/src/main/target/authoring/c/matches.ts
@@ -102,7 +102,11 @@ const calldataMatchesScopings =
   <S extends TupleScopings<any>>(
     scopings: S,
     abiTypes: readonly AbiType[],
-    selector?: `0x${string}`
+    options: {
+      selector?: `0x${string}`
+      etherWithinAllowance?: `0x${string}`
+      callWithinAllowance?: `0x${string}`
+    } = {}
   ) =>
   (abiType?: ParamType) => {
     const paramTypes = abiTypes.map((abiType) => ParamType.from(abiType))
@@ -113,6 +117,8 @@ const calldataMatchesScopings =
         `Can only use \`calldataMatches\` on bytes type params, got: ${abiType.type}`
       )
     }
+
+    const { selector, etherWithinAllowance, callWithinAllowance } = options
 
     // map scoping items to conditions
     const conditions: (Condition | undefined)[] = paramTypes.map(
@@ -194,7 +200,11 @@ type CalldataMatches = {
   <S extends TupleScopings<any>>(
     scopings: S,
     abiTypes: readonly AbiType[],
-    selector?: `0x${string}`
+    options?: {
+      selector?: `0x${string}`
+      etherWithinAllowance?: `0x${string}`
+      callWithinAllowance?: `0x${string}`
+    }
   ): (abiType?: ParamType) => Condition
 
   /**
@@ -211,13 +221,17 @@ type CalldataMatches = {
 export const calldataMatches: CalldataMatches = <S extends TupleScopings<any>>(
   scopingsOrFunctionPermission: S | FunctionPermission,
   abiTypes?: readonly AbiType[],
-  selector?: `0x${string}`
+  options?: {
+    selector?: `0x${string}`
+    etherWithinAllowance?: `0x${string}`
+    callWithinAllowance?: `0x${string}`
+  }
 ): ((abiType?: ParamType) => Condition) => {
   return abiTypes
     ? calldataMatchesScopings(
         scopingsOrFunctionPermission as S,
         abiTypes,
-        selector
+        options
       )
     : calldataMatchesFunctionPermission(
         scopingsOrFunctionPermission as unknown as FunctionPermission

--- a/packages/sdk/src/main/target/authoring/c/matches.ts
+++ b/packages/sdk/src/main/target/authoring/c/matches.ts
@@ -137,6 +137,22 @@ const calldataMatchesScopings =
       ),
     }
 
+    if (etherWithinAllowance) {
+      matchesCondition.children.push({
+        paramType: ParameterType.None,
+        operator: Operator.EtherWithinAllowance,
+        compValue: etherWithinAllowance,
+      })
+    }
+
+    if (callWithinAllowance) {
+      matchesCondition.children.push({
+        paramType: ParameterType.None,
+        operator: Operator.CallWithinAllowance,
+        compValue: callWithinAllowance,
+      })
+    }
+
     if (selector) {
       if (selector.length !== 10) {
         throw new Error(

--- a/packages/sdk/src/main/target/condition/normalizeCondition.test.ts
+++ b/packages/sdk/src/main/target/condition/normalizeCondition.test.ts
@@ -343,13 +343,17 @@ suite("normalizeCondition()", () => {
     })
   })
 
-  it("keeps the EtherWithinAllowance as the only child of Calldata.Matches", () => {
+  it("keeps EtherWithinAllowance while pruning trailing Pass nodes on Calldata.Matches", () => {
     expect(
       stripIds(
         normalizeCondition({
           paramType: ParameterType.Calldata,
           operator: Operator.Matches,
           children: [
+            {
+              paramType: ParameterType.Static,
+              operator: Operator.Pass,
+            },
             {
               paramType: ParameterType.None,
               operator: Operator.EtherWithinAllowance,

--- a/packages/sdk/src/main/target/condition/normalizeCondition.test.ts
+++ b/packages/sdk/src/main/target/condition/normalizeCondition.test.ts
@@ -343,7 +343,7 @@ suite("normalizeCondition()", () => {
     })
   })
 
-  it("keeps EtherWithinAllowance while pruning trailing Pass nodes on Calldata.Matches", () => {
+  it("keeps EtherWithinAllowance (moving it to the end) while pruning trailing Pass nodes on Calldata.Matches", () => {
     expect(
       stripIds(
         normalizeCondition({
@@ -351,13 +351,17 @@ suite("normalizeCondition()", () => {
           operator: Operator.Matches,
           children: [
             {
+              paramType: ParameterType.None,
+              operator: Operator.EtherWithinAllowance,
+              compValue: encodeKey("test-allowance"),
+            },
+            {
               paramType: ParameterType.Static,
               operator: Operator.Pass,
             },
             {
-              paramType: ParameterType.None,
-              operator: Operator.EtherWithinAllowance,
-              compValue: encodeKey("test-allowance"),
+              paramType: ParameterType.Static,
+              operator: Operator.Pass,
             },
           ],
         })
@@ -366,6 +370,11 @@ suite("normalizeCondition()", () => {
       paramType: ParameterType.Calldata,
       operator: Operator.Matches,
       children: [
+        {
+          // first child is always kept
+          paramType: ParameterType.Static,
+          operator: Operator.Pass,
+        },
         {
           paramType: ParameterType.None,
           operator: Operator.EtherWithinAllowance,


### PR DESCRIPTION
the current `c.etherWithinAllowance` and `c.callWithinAllowance` conditions are quite useless as it's unclear how to define them as children of `c.calldataMatches`. 

This PR turns them into options of `c.calldataMatches` instead.