### PR TITLE
feat(app): security-check banner on Roles modifier routes

### DIFF
--- a/packages/app/app/[mod]/layout.tsx
+++ b/packages/app/app/[mod]/layout.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from "react"
+import { parseModParam } from "@/app/params"
+import SecurityNotice from "@/components/SecurityNotice"
+
+/**
+ * Wraps every route scoped to a specific Roles modifier (`/[mod]/...`). Surfaces
+ * the security-check banner for that modifier above the page. Routes without a
+ * mod in their path (the landing page, `/permissions/...`) don't get a layout
+ * here, so they're unaffected.
+ */
+export default async function ModLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ mod: string }>
+}) {
+  const { mod } = await params
+  const parsed = parseModParam(mod)
+
+  return (
+    <>
+      {parsed && (
+        <Suspense fallback={null}>
+          <SecurityNotice mod={parsed} />
+        </Suspense>
+      )}
+      {children}
+    </>
+  )
+}

--- a/packages/app/components/SecurityNotice/Banner.tsx
+++ b/packages/app/components/SecurityNotice/Banner.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { useState } from "react"
+import classes from "./style.module.css"
+
+const NOTICE_URL = "https://x.com/zodiaceco/status/2061862711206502902"
+
+/**
+ * The dismissable warning banner. Dismissal is in-memory only, so it reappears
+ * on reload — the notice should keep nagging until the setup is remediated.
+ */
+export default function Banner({
+  status,
+  affectedCount,
+  remediationUrl,
+}: {
+  status: "affected" | "incomplete"
+  affectedCount: number
+  remediationUrl: string
+}) {
+  const [dismissed, setDismissed] = useState(false)
+  if (dismissed) {
+    return null
+  }
+
+  return (
+    <div role="alert" className={classes.banner}>
+      <div className={classes.content}>
+        <span className={classes.icon} aria-hidden>
+          ⚠️
+        </span>
+        <span className={classes.headline}>
+          Security update: a vulnerability affects Zodiac Roles Modifier v2 and
+          Delay Modifier v1.1.0 in specific setups.
+        </span>
+        {status === "affected" ? (
+          <span>
+            This Roles modifier is affected — {affectedCount} Safe
+            {affectedCount === 1 ? "" : "s"} reachable through it still need
+            {affectedCount === 1 ? "s" : ""} action.{" "}
+            <a href={remediationUrl} className={classes.action}>
+              Review &amp; remediate
+            </a>
+          </span>
+        ) : (
+          <span>
+            We couldn&apos;t fully check this Roles modifier — its status is
+            unknown.{" "}
+            <a href={remediationUrl} className={classes.action}>
+              Open the checker
+            </a>
+          </span>
+        )}
+        <a
+          href={NOTICE_URL}
+          target="_blank"
+          rel="noreferrer noopener"
+          className={classes.action}
+        >
+          Read the full notice
+        </a>
+      </div>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss"
+        className={classes.dismiss}
+      >
+        ✕
+      </button>
+    </div>
+  )
+}

--- a/packages/app/components/SecurityNotice/index.tsx
+++ b/packages/app/components/SecurityNotice/index.tsx
@@ -1,0 +1,53 @@
+import { Mod } from "@/app/params"
+import Banner from "./Banner"
+
+// The public Zodiac security-check API. We call it server-side: it sets no CORS
+// header (so a cross-origin browser fetch would be blocked), and this keeps the
+// on-chain walk off the client.
+const ZODIAC_APP_ORIGIN = "https://app.zodiac.eco"
+
+type SecurityCheckResult = {
+  status: "safe" | "affected" | "incomplete"
+  checkedVaultCount: number
+  erroredVaultCount: number
+  affectedSafes: { chainId: number; address: string; fallbackHandler: string }[]
+}
+
+/**
+ * Check a single Roles modifier against the shared Zodiac security-check API and,
+ * when it is affected (or couldn't be fully checked), render a warning banner
+ * pointing at the remediation tool. Rendered inside a Suspense boundary so the
+ * on-chain walk never blocks the page; a clean or failed check shows nothing.
+ */
+export default async function SecurityNotice({ mod }: { mod: Mod }) {
+  const result = await checkMod(mod)
+
+  if (result == null || result.status === "safe") {
+    return null
+  }
+
+  return (
+    <Banner
+      status={result.status}
+      affectedCount={result.affectedSafes.length}
+      remediationUrl={`${ZODIAC_APP_ORIGIN}/public/fallback-handler?address=${mod.address}&chainId=${mod.chainId}`}
+    />
+  )
+}
+
+async function checkMod(mod: Mod): Promise<SecurityCheckResult | null> {
+  try {
+    const response = await fetch(
+      `${ZODIAC_APP_ORIGIN}/public/api/security-check?safes=${mod.chainId}:${mod.address}`,
+      // Cache briefly so navigating between a mod's pages doesn't re-walk on
+      // every request, while still reflecting remediation within a few minutes.
+      { next: { revalidate: 120 } },
+    )
+    if (!response.ok) {
+      return null
+    }
+    return (await response.json()) as SecurityCheckResult
+  } catch {
+    return null
+  }
+}

--- a/packages/app/components/SecurityNotice/style.module.css
+++ b/packages/app/components/SecurityNotice/style.module.css
@@ -1,0 +1,58 @@
+.banner {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-2) var(--spacing-3);
+  background: #fbbf24;
+  color: #451a03;
+  border-bottom: 1px solid rgba(69, 26, 3, 0.35);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.content {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-1) var(--spacing-3);
+}
+
+.icon {
+  flex-shrink: 0;
+}
+
+.headline {
+  font-weight: 600;
+}
+
+/* Override the global dark link color — the banner is on a light background. */
+.banner a.action {
+  color: #451a03;
+  font-weight: 600;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
+.banner a.action:hover {
+  color: #78350f;
+}
+
+.dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: #451a03;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px 4px;
+}
+
+.dismiss:hover {
+  opacity: 0.7;
+}


### PR DESCRIPTION
## What

Adds a warning banner to the Roles app on every route scoped to a specific Roles modifier (`/[mod]/...`) when that modifier is **affected** by the Zodiac Roles v2 / Delay v1.1.0 fallback-handler vulnerability.

## How

- **`app/[mod]/layout.tsx`** — a layout that wraps only `/[mod]/...` routes (the ones whose path contains a Roles mod address). Routes without a mod in their path (the landing page, `/permissions/...`) are untouched. The banner streams in via `<Suspense>`, so the on-chain check never blocks the page render.
- **`components/SecurityNotice/`** — `index.tsx` is a server component that calls the shared public API (`https://app.zodiac.eco/public/api/security-check?safes=<chainId>:<mod>`). It runs **server-side** because the public API sets no CORS header (a browser cross-origin fetch would be blocked) and to keep the on-chain walk off the client. `Banner.tsx` is the dismissable client view; `style.module.css` matches the app's theme.
- A clean (`safe`) or failed check renders nothing. An `affected` result shows how many reachable Safes still need action and links to the `/public/fallback-handler` remediation tool. `incomplete` shows an "unknown status" variant. Dismissal is in-memory, so the notice reappears on reload until the setup is remediated.

## Verified

Against real data on `localhost`:
- Affected Base Roles mod → banner with the correct count + remediation link.
- Remediated/safe mod → no banner.
- Landing page / non-`[mod]` routes → no banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)