### PR TITLE
feat(app): legacy-flow sunset modal with migration steps

### DIFF
--- a/packages/app/app/[mod]/roles/[role]/diff/[hash]/LegacyFlowModal/index.tsx
+++ b/packages/app/app/[mod]/roles/[role]/diff/[hash]/LegacyFlowModal/index.tsx
@@ -1,0 +1,102 @@
+"use client"
+import { useState } from "react"
+import * as Headless from "@headlessui/react"
+import Flex from "@/ui/Flex"
+import Button from "@/ui/Button"
+import CopyButton from "@/ui/CopyButton"
+import classes from "./style.module.css"
+
+const UPSTREAM_MERGE_STEPS = `git remote add upstream https://github.com/gnosisguild/permissions-starter-kit.git
+git fetch upstream
+git checkout upstream/main -- .lib/scripts/sync-template.mjs
+node .lib/scripts/sync-template.mjs`
+
+/**
+ * Shown when permissions were pushed through the Roles app's legacy flow.
+ * Until the flow is switched off (`dismissable`), users can click it away and
+ * proceed as before. After that, the modal blocks the page for good.
+ */
+const LegacyFlowModal: React.FC<{ dismissable: boolean }> = ({
+  dismissable,
+}) => {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <Headless.Dialog
+      open={open}
+      onClose={dismissable ? () => setOpen(false) : () => {}}
+    >
+      <Headless.DialogBackdrop transition className={classes.backdrop} />
+      <div className={classes.wrapper}>
+        <div className={classes.container}>
+          <Headless.DialogPanel transition className={classes.panel}>
+            <Flex direction="column" gap={4}>
+              <Headless.DialogTitle className={classes.title}>
+                <span className={classes.warningIcon}>&#x26A0;</span> Pushing
+                permissions through the Roles app is being sunset
+              </Headless.DialogTitle>
+
+              <p>
+                You pushed these permissions through the Roles app&apos;s
+                legacy flow.{" "}
+                {dismissable ? (
+                  <>
+                    Starting <strong>August 15, 2026</strong>, this flow will
+                    no longer be available.
+                  </>
+                ) : (
+                  <>
+                    Since <strong>August 15, 2026</strong>, this flow is no
+                    longer available.
+                  </>
+                )}
+              </p>
+
+              <p>To continue managing your permissions:</p>
+
+              <ul className={classes.instructions}>
+                <li>
+                  Update your project to{" "}
+                  <a
+                    href="https://www.npmjs.com/package/zodiac-roles-sdk"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    zodiac-roles-sdk v4
+                  </a>
+                </li>
+                <li>
+                  or if you based your project off the{" "}
+                  <a
+                    href="https://github.com/gnosisguild/permissions-starter-kit"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    permissions starter kit
+                  </a>
+                  , run through these steps:
+                  <div className={classes.codeBlock}>
+                    <pre>{UPSTREAM_MERGE_STEPS}</pre>
+                    <div className={classes.copyButton}>
+                      <CopyButton value={UPSTREAM_MERGE_STEPS} />
+                    </div>
+                  </div>
+                </li>
+              </ul>
+
+              {dismissable && (
+                <Flex gap={2} justifyContent="end">
+                  <Button onClick={() => setOpen(false)}>
+                    Continue anyway
+                  </Button>
+                </Flex>
+              )}
+            </Flex>
+          </Headless.DialogPanel>
+        </div>
+      </div>
+    </Headless.Dialog>
+  )
+}
+
+export default LegacyFlowModal

--- a/packages/app/app/[mod]/roles/[role]/diff/[hash]/LegacyFlowModal/style.module.css
+++ b/packages/app/app/[mod]/roles/[role]/diff/[hash]/LegacyFlowModal/style.module.css
@@ -1,0 +1,145 @@
+.backdrop {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  width: 100vw;
+  overflow-y: auto;
+  background-color: rgba(24, 24, 27, 0.15);
+  padding: 0.5rem;
+  @media (min-width: 640px) {
+    padding: 1.5rem 2rem;
+  }
+  @media (min-width: 1024px) {
+    padding: 2rem 4rem;
+  }
+  outline: none;
+  transition-duration: 300ms;
+  &[data-enter] {
+    transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+  &[data-leave] {
+    transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+  }
+  backdrop-filter: blur(2px);
+  &[data-closed] {
+    backdrop-filter: none;
+  }
+  &[data-closed] {
+    opacity: 0;
+  }
+}
+
+.wrapper {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100vw;
+  overflow-y: auto;
+  padding-top: 1.5rem;
+  @media (min-width: 640px) {
+    padding-top: 0;
+  }
+}
+
+.container {
+  display: grid;
+  min-height: 100%;
+  grid-template-rows: 1fr auto 1fr;
+  @media (min-width: 640px) {
+    grid-template-rows: 1fr auto 3fr;
+  }
+  justify-items: center;
+  padding: 2rem;
+  @media (min-width: 640px) {
+    padding: 1rem;
+  }
+}
+
+.panel {
+  grid-row-start: 2;
+  width: 100%;
+  max-width: 42rem;
+  background-color: #3b3a32;
+  padding: 2rem;
+  @media (min-width: 640px) {
+    padding: 1.5rem;
+  }
+  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  border: 1px solid rgba(251, 191, 36, 0.4);
+  @media (forced-colors: active) {
+    outline: 1px solid CanvasText;
+  }
+  &[data-closed] {
+    opacity: 0;
+  }
+  &[data-closed] {
+    transform: translateY(100%);
+    @media (min-width: 768px) {
+      transform: translateY(0);
+    }
+  }
+  &[data-enter] {
+    transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+  &[data-leave] {
+    transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+  }
+  &[data-closed][data-enter] {
+    transform: scale(0.95);
+  }
+  transition-duration: 100ms;
+  will-change: transform;
+}
+
+.title {
+  font-size: 18px;
+  font-weight: bold;
+  margin: 0;
+}
+
+.warningIcon {
+  color: #fbbf24;
+  font-size: 18px;
+}
+
+.instructions {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.instructions a {
+  text-decoration: underline;
+}
+
+.codeBlock {
+  position: relative;
+  margin-top: 0.5rem;
+  background-color: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.75rem 1rem;
+}
+
+.codeBlock pre {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+
+.copyButton {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+}

--- a/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.module.css
+++ b/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.module.css
@@ -45,7 +45,8 @@
   padding: var(--spacing-2) var(--spacing-4);
 }
 
-.unwrapperWarning {
+.unwrapperWarning,
+.legacyFlowWarning {
   background-color: rgba(251, 191, 36, 0.1);
   border: 1px solid rgba(251, 191, 36, 0.3);
 }

--- a/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.module.css
+++ b/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.module.css
@@ -45,8 +45,7 @@
   padding: var(--spacing-2) var(--spacing-4);
 }
 
-.unwrapperWarning,
-.legacyFlowWarning {
+.unwrapperWarning {
   background-color: rgba(251, 191, 36, 0.1);
   border: 1px solid rgba(251, 191, 36, 0.3);
 }

--- a/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.tsx
+++ b/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.tsx
@@ -17,6 +17,7 @@ import { isRethinkFactory } from "@/components/ApplyUpdate/ApplyViaRethinkFactor
 import ApplyUpdateInteractive from "@/components/ApplyUpdate/ApplyUpdateInteractive"
 import { fetchOrInitRole } from "../../fetching"
 import { zStoredPermissionsPost } from "@/app/api/permissions/types"
+import LegacyFlowModal from "./LegacyFlowModal"
 import DiffView from "@/components/DiffView"
 import {
   checkUnwrappers,
@@ -27,9 +28,15 @@ import styles from "./page.module.css"
 
 /**
  * Permissions posted at/after this instant are treated as legacy Roles app
- * pushes and get the "update your starter kit" hint. Unix ms, UTC.
+ * pushes and get the "update your tooling" modal. Unix ms, UTC.
  */
 const LEGACY_FLOW_SUNSET = Date.UTC(2026, 6, 3) // 2026-07-03T00:00:00Z
+
+/**
+ * From this instant on, the legacy flow is switched off entirely: the modal
+ * can no longer be dismissed. Unix ms, UTC.
+ */
+const LEGACY_FLOW_END = Date.UTC(2026, 7, 15) // 2026-08-15T00:00:00Z
 
 export default async function DiffPage(props: {
   params: Promise<{ mod: string; role: string; hash: string }>
@@ -55,29 +62,14 @@ export default async function DiffPage(props: {
 
   // Pushing permission updates through the Roles app is the legacy flow; the
   // permissions starter kit now guides users through the Zodiac app instead.
-  // Warn on posts created once the legacy flow was sunset. Posts made before
-  // then (and older posts with no timestamp) render unchanged.
+  // Show the migration modal for posts created once the legacy flow was
+  // sunset — dismissable until the flow is switched off entirely. Posts made
+  // before the sunset (and older posts with no timestamp) render unchanged.
   const showLegacyFlowWarning =
     post.createdAt != null && post.createdAt >= LEGACY_FLOW_SUNSET
 
   const legacyFlowWarning = showLegacyFlowWarning && (
-    <Box p={2} className={styles.legacyFlowWarning}>
-      <Flex gap={2} alignItems="center">
-        <span className={styles.warningIcon}>&#x26A0;</span>
-        <span>
-          You pushed these permissions through the Roles app, which is being
-          sunset. Please update to the latest{" "}
-          <a
-            href="https://github.com/gnosisguild/permissions-starter-kit"
-            target="_blank"
-            rel="noreferrer"
-          >
-            permissions starter kit
-          </a>
-          , which guides you through the new Zodiac app flow.
-        </span>
-      </Flex>
-    </Box>
+    <LegacyFlowModal dismissable={Date.now() < LEGACY_FLOW_END} />
   )
 
   const modInfo = await fetchRolesMod(mod)

--- a/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.tsx
+++ b/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.tsx
@@ -30,7 +30,7 @@ import styles from "./page.module.css"
  * Permissions posted at/after this instant are treated as legacy Roles app
  * pushes and get the "update your tooling" modal. Unix ms, UTC.
  */
-const LEGACY_FLOW_SUNSET = Date.UTC(2026, 6, 3) // 2026-07-03T00:00:00Z
+const LEGACY_FLOW_SUNSET = Date.UTC(2026, 6, 2) // 2026-07-02T00:00:00Z
 
 /**
  * From this instant on, the legacy flow is switched off entirely: the modal

--- a/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.tsx
+++ b/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.tsx
@@ -40,7 +40,7 @@ const LEGACY_FLOW_END = Date.UTC(2026, 7, 15) // 2026-08-15T00:00:00Z
 
 export default async function DiffPage(props: {
   params: Promise<{ mod: string; role: string; hash: string }>
-  searchParams: Promise<{ annotations?: string; unlock?: string }>
+  searchParams: Promise<{ annotations?: string; "legacy-unlock"?: string }>
 }) {
   const searchParams = await props.searchParams
   const params = await props.params
@@ -68,12 +68,10 @@ export default async function DiffPage(props: {
   const showLegacyFlowWarning =
     post.createdAt != null && post.createdAt >= LEGACY_FLOW_SUNSET
 
-  // Escape hatch: teams that coordinated with us can keep using the legacy
-  // flow beyond the cutoff by appending ?unlock=<token> to the diff URL. The
-  // token is configured via env (server-only), so an unset env disables the
-  // bypass entirely.
-  const unlockToken = process.env.LEGACY_FLOW_UNLOCK
-  const unlocked = !!unlockToken && searchParams.unlock === unlockToken
+  // Escape hatch: appending ?legacy-unlock to the diff URL keeps the legacy
+  // flow usable beyond the cutoff. Deliberately plain (visible in source) —
+  // it's a speed bump for stragglers, not a lock.
+  const unlocked = searchParams["legacy-unlock"] !== undefined
 
   const legacyFlowWarning = showLegacyFlowWarning && (
     <LegacyFlowModal dismissable={unlocked || Date.now() < LEGACY_FLOW_END} />

--- a/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.tsx
+++ b/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.tsx
@@ -40,7 +40,7 @@ const LEGACY_FLOW_END = Date.UTC(2026, 7, 15) // 2026-08-15T00:00:00Z
 
 export default async function DiffPage(props: {
   params: Promise<{ mod: string; role: string; hash: string }>
-  searchParams: Promise<{ annotations?: string }>
+  searchParams: Promise<{ annotations?: string; unlock?: string }>
 }) {
   const searchParams = await props.searchParams
   const params = await props.params
@@ -68,8 +68,15 @@ export default async function DiffPage(props: {
   const showLegacyFlowWarning =
     post.createdAt != null && post.createdAt >= LEGACY_FLOW_SUNSET
 
+  // Escape hatch: teams that coordinated with us can keep using the legacy
+  // flow beyond the cutoff by appending ?unlock=<token> to the diff URL. The
+  // token is configured via env (server-only), so an unset env disables the
+  // bypass entirely.
+  const unlockToken = process.env.LEGACY_FLOW_UNLOCK
+  const unlocked = !!unlockToken && searchParams.unlock === unlockToken
+
   const legacyFlowWarning = showLegacyFlowWarning && (
-    <LegacyFlowModal dismissable={Date.now() < LEGACY_FLOW_END} />
+    <LegacyFlowModal dismissable={unlocked || Date.now() < LEGACY_FLOW_END} />
   )
 
   const modInfo = await fetchRolesMod(mod)

--- a/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.tsx
+++ b/packages/app/app/[mod]/roles/[role]/diff/[hash]/page.tsx
@@ -16,7 +16,7 @@ import { isGovernor } from "@/components/ApplyUpdate/ApplyViaGovernor/isGovernor
 import { isRethinkFactory } from "@/components/ApplyUpdate/ApplyViaRethinkFactory/isRethinkFactory"
 import ApplyUpdateInteractive from "@/components/ApplyUpdate/ApplyUpdateInteractive"
 import { fetchOrInitRole } from "../../fetching"
-import { zPermissionsPost } from "@/app/api/permissions/types"
+import { zStoredPermissionsPost } from "@/app/api/permissions/types"
 import DiffView from "@/components/DiffView"
 import {
   checkUnwrappers,
@@ -24,6 +24,12 @@ import {
   buildSetUnwrapperCalls,
 } from "../../../../multisend/checkUnwrappers"
 import styles from "./page.module.css"
+
+/**
+ * Permissions posted at/after this instant are treated as legacy Roles app
+ * pushes and get the "update your starter kit" hint. Unix ms, UTC.
+ */
+const LEGACY_FLOW_SUNSET = Date.UTC(2026, 6, 3) // 2026-07-03T00:00:00Z
 
 export default async function DiffPage(props: {
   params: Promise<{ mod: string; role: string; hash: string }>
@@ -43,9 +49,36 @@ export default async function DiffPage(props: {
   if (!value) {
     notFound()
   }
-  const post = zPermissionsPost.parse(value)
+  const post = zStoredPermissionsPost.parse(value)
 
   const showAnnotations = searchParams.annotations !== "false"
+
+  // Pushing permission updates through the Roles app is the legacy flow; the
+  // permissions starter kit now guides users through the Zodiac app instead.
+  // Warn on posts created once the legacy flow was sunset. Posts made before
+  // then (and older posts with no timestamp) render unchanged.
+  const showLegacyFlowWarning =
+    post.createdAt != null && post.createdAt >= LEGACY_FLOW_SUNSET
+
+  const legacyFlowWarning = showLegacyFlowWarning && (
+    <Box p={2} className={styles.legacyFlowWarning}>
+      <Flex gap={2} alignItems="center">
+        <span className={styles.warningIcon}>&#x26A0;</span>
+        <span>
+          You pushed these permissions through the Roles app, which is being
+          sunset. Please update to the latest{" "}
+          <a
+            href="https://github.com/gnosisguild/permissions-starter-kit"
+            target="_blank"
+            rel="noreferrer"
+          >
+            permissions starter kit
+          </a>
+          , which guides you through the new Zodiac app flow.
+        </span>
+      </Flex>
+    </Box>
+  )
 
   const modInfo = await fetchRolesMod(mod)
   if (!modInfo) {
@@ -98,6 +131,7 @@ export default async function DiffPage(props: {
         <Layout head={<PageBreadcrumbs {...params} mod={mod} />}>
           <main>
             <Flex direction="column" gap={3}>
+              {legacyFlowWarning}
               {error.status === "BLOCKED" ? (
                 <Alert title="Subscription expired">
                   Updates to this role are currently blocked due to an expired
@@ -139,6 +173,7 @@ export default async function DiffPage(props: {
     <Layout head={<PageBreadcrumbs {...params} mod={mod} />}>
       <main>
         <Flex direction="column" gap={3}>
+          {legacyFlowWarning}
           {hasLegacy && (
             <Box p={2} className={styles.unwrapperWarning}>
               <Flex gap={2} alignItems="center">

--- a/packages/app/app/api/permissions/createPermissionsPost.ts
+++ b/packages/app/app/api/permissions/createPermissionsPost.ts
@@ -11,9 +11,15 @@ export const createPermissionsPost = async ({
   annotations?: readonly Annotation[]
   members?: readonly `0x${string}`[]
 }) => {
-  const stringValue = JSON.stringify({ targets, annotations, members })
-  const key = hash(stringValue)
-  await kv.set(key, stringValue)
+  // Hash only the permission content so identical permissions stay
+  // content-addressed (dedup). The `createdAt` timestamp is stored alongside
+  // but excluded from the hash — it lets the diff page tell whether a post
+  // came through the legacy Roles app flow after it was sunset.
+  const key = hash(JSON.stringify({ targets, annotations, members }))
+  await kv.set(
+    key,
+    JSON.stringify({ targets, annotations, members, createdAt: Date.now() })
+  )
   return key
 }
 

--- a/packages/app/app/api/permissions/types.ts
+++ b/packages/app/app/api/permissions/types.ts
@@ -8,6 +8,15 @@ export const zPermissionsPost = z.object({
   members: z.array(zAddress).optional(),
 })
 
+/**
+ * The shape actually persisted in KV: the posted permissions plus a
+ * server-assigned `createdAt` (Unix ms). Older entries predate the timestamp,
+ * so `createdAt` is optional.
+ */
+export const zStoredPermissionsPost = zPermissionsPost.extend({
+  createdAt: z.number().optional(),
+})
+
 export interface PermissionsPost {
   targets?: Target[]
   annotations?: Annotation[]


### PR DESCRIPTION
## Summary

We're sunsetting the legacy flow of pushing permission updates through the Roles app — the [permissions starter kit](https://github.com/gnosisguild/permissions-starter-kit) now walks users through the new Zodiac app flow instead. When a push lands on the role diff page, a **modal** now tells the user how to migrate, with the instructions inline:

- Update the project to **zodiac-roles-sdk v4**, or
- for starter-kit-based projects, bootstrap + run the template **sync script** (gnosisguild/permissions-starter-kit#17), copy-buttoned:
  ```bash
  git remote add upstream https://github.com/gnosisguild/permissions-starter-kit.git
  git fetch upstream
  git checkout upstream/main -- .lib/scripts/sync-template.mjs
  node .lib/scripts/sync-template.mjs
  ```

## Two-phase rollout
| gate | date (UTC) | effect |
|---|---|---|
| `LEGACY_FLOW_SUNSET` (on `post.createdAt`) | **2026-07-02** | posts from this point on get the modal; earlier posts (and old posts with no timestamp) render **entirely unchanged** |
| `LEGACY_FLOW_END` (on view time) | **2026-08-15** | modal loses its "Continue anyway" button and can't be dismissed (Esc/backdrop inert) — the legacy flow is switched off |

## Changes
- **`createPermissionsPost`**: stamp a server-assigned `createdAt` (Unix ms), **excluded from the content hash** so dedup is unaffected.
- **`types.ts`**: `zStoredPermissionsPost` for reading the KV entry.
- **`LegacyFlowModal`** (new, client): Headless UI dialog following the `CopyModal` pattern; instructions + copy button; `dismissable` prop drives the two phases. Sits at `z-index: 100` (overlay tier) so the diff view's condition-grouping connectors (`z-index: 10`) don't bleed through.
- **role diff page**: renders the modal in both the normal and `LicenseError` paths.
