### PR TITLE
fix(app): governor-owned mods crash the diff page during SSR

### DIFF
--- a/packages/app/components/ApplyUpdate/ApplyUpdateInteractive.tsx
+++ b/packages/app/components/ApplyUpdate/ApplyUpdateInteractive.tsx
@@ -70,9 +70,14 @@ const ApplyUpdateInteractive: React.FC<Props> = ({
       <ApplyViaGovernor
         calls={allCalls}
         owner={owner}
+        // `window` is undefined during SSR; the description is only read in
+        // the propose() click handler, which always runs post-hydration where
+        // the full URL is available.
         description={`Update permissions of the ${decodeKey(
           roleKey
-        )} role. Review the update at ${window.location.href}`}
+        )} role. Review the update at ${
+          typeof window === "undefined" ? "" : window.location.href
+        }`}
         chainId={chainId}
       />
     ) : (


### PR DESCRIPTION
## Summary

Every `/[mod]/roles/[role]/diff/[hash]` page for a Roles mod **owned by an OpenZeppelin Governor** returns **HTTP 500** on prod: `ApplyUpdateInteractive` evaluates `window.location.href` at render time in its governor branch, and `window` doesn't exist during SSR. The stream dies mid-flight — the response is the bare app shell plus a truncated RSC payload.

This is pre-existing (the line shipped in #468), but surfaced today while testing the #488 sunset modal against the rethink `boreal` mod, whose owner (`0x9695…155a`) responds to `COUNTING_MODE()` → `applyType = "governor"`. It went unnoticed because the client partially recovers from the flight payload and the starter kit's `fetch(diffUrl)` prewarm never checked the status code.

## Fix
Guard the render-time access. The `description` prop is only read inside the `propose()` click handler (never rendered), and clicks always happen post-hydration where the full URL is available — so the SSR fallback value is never observable.

## Verification (production build, local, against the real boreal diff)
| | before | after |
|---|---|---|
| status | 500 | **200** |
| response | bare shell + truncated 411KB flight | complete 708KB SSR |
| server log | `ReferenceError: window is not defined` | clean |
| #488 modal | present in payload | present in payload (`dismissable: true`) |

Also audited the other `window.` references in the app (`ApplyViaSafe`, `Anchor`, `Apply.tsx`, `IndividualPermissionsExpandable`) — all are inside `useEffect`/guards or behind an effect-set state, so this was the only render-time offender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012my5oZkF1tFnhsXcNzSkKV