### PR TITLE
Make rounding conservative in price conversion and ratio checks

### DIFF
--- a/packages/evm/contracts/common/PriceConversion.sol
+++ b/packages/evm/contracts/common/PriceConversion.sol
@@ -25,20 +25,28 @@ library PriceConversion {
      * @notice Applies exchange rate conversion to an amount.
      * @param amount The amount to convert
      * @param adapter Price adapter address
+     * @param roundUp Whether to round the result up (conservative for
+     *        allowance consumption) or down
      * @return status Ok or error status from adapter
      * @return result Amount multiplied by price and divided by 10^18
      */
     function convert(
         uint256 amount,
         address adapter,
-        bytes memory params
+        bytes memory params,
+        bool roundUp
     ) internal view returns (Status, uint256) {
         (Status status, uint256 price) = _getPrice(adapter, params);
         if (status != Status.Ok) {
             return (status, 0);
         }
 
-        return (Status.Ok, (amount * price) / ONE);
+        uint256 product = amount * price;
+        uint256 result = product / ONE;
+        if (roundUp && product % ONE != 0) {
+            result += 1;
+        }
+        return (Status.Ok, result);
     }
 
     /**

--- a/packages/evm/contracts/core/evaluate/WithinAllowanceChecker.sol
+++ b/packages/evm/contracts/core/evaluate/WithinAllowanceChecker.sol
@@ -150,7 +150,10 @@ library WithinAllowanceChecker {
             }
         }
 
-        return PriceConversion.convert(value, adapter, params);
+        // Round up: dust amounts always consume at least 1, and truncation
+        // errors accumulate against the allowance rather than in favor of
+        // the spender.
+        return PriceConversion.convert(value, adapter, params, true);
     }
 
     /// @dev Ceiling division. Returns 0 for 0, otherwise ⌈a / b⌉.

--- a/packages/evm/contracts/core/evaluate/WithinRatioChecker.sol
+++ b/packages/evm/contracts/core/evaluate/WithinRatioChecker.sol
@@ -144,7 +144,8 @@ library WithinRatioChecker {
             PriceConversion.convert(
                 value * (10 ** (precision - decimals)),
                 adapter,
-                params
+                params,
+                false
             );
     }
 

--- a/packages/evm/contracts/core/evaluate/WithinRatioChecker.sol
+++ b/packages/evm/contracts/core/evaluate/WithinRatioChecker.sol
@@ -82,17 +82,33 @@ library WithinRatioChecker {
          *                 relativeAmount × priceRel
          *   ratio (bps) = ───────────────────────── × 10,000
          *                 referenceAmount × priceRef
+         *
+         * Rounding always favors rejection: minRatio checks the floored
+         * ratio, maxRatio the ceiled ratio. Truncation can therefore
+         * never mask a bound violation.
          */
-        uint256 ratio = (relativeAmount * BPS) / referenceAmount;
+        uint256 scaledRelative = relativeAmount * BPS;
 
-        if (config.minRatio != 0 && ratio < config.minRatio) {
+        if (
+            config.minRatio != 0 &&
+            scaledRelative / referenceAmount < config.minRatio
+        ) {
             return Status.RatioBelowMin;
         }
-        if (config.maxRatio != 0 && ratio > config.maxRatio) {
+        if (
+            config.maxRatio != 0 &&
+            _ceilDiv(scaledRelative, referenceAmount) > config.maxRatio
+        ) {
             return Status.RatioAboveMax;
         }
 
         return Status.Ok;
+    }
+
+    /// @dev Ceiling division. Returns 0 for 0, otherwise ⌈a / b⌉.
+    function _ceilDiv(uint256 a, uint256 b) private pure returns (uint256) {
+        if (a == 0) return 0;
+        return (a - 1) / b + 1;
     }
 
     /**

--- a/packages/evm/test/operators/23WithinRatio.spec.ts
+++ b/packages/evm/test/operators/23WithinRatio.spec.ts
@@ -248,6 +248,90 @@ describe("Operator - WithinRatio", () => {
           await expect(invoke(10, 1000)).to.not.be.revert(ethers);
         });
       });
+
+      // Both bound checks must round the ratio towards rejection. Otherwise
+      // sub-bps truncation masks genuine bound violations: a ratio of up to
+      // (maxRatio + 1) - 1wei would floor to maxRatio and pass.
+      describe("sub-bps rounding", () => {
+        it("reverts when ratio exceeds maxRatio by less than 1 bps", async () => {
+          const { roles, allowFunction, invoke } =
+            await loadFixture(setupTwoParams);
+
+          const compValue = encodeWithinRatioCompValue({
+            referencePluckIndex: 1,
+            referenceDecimals: 0,
+            relativePluckIndex: 0,
+            relativeDecimals: 0,
+            minRatio: 0,
+            maxRatio: 10000, // 100%
+          });
+
+          await allowFunction(
+            flattenCondition(matchesWithRatio([pluck(0), pluck(1)], compValue)),
+          );
+
+          // true ratio = 10002/10001 = 10000.9999 bps > 10000 cap.
+          // A floored ratio truncates to 10000 and lets the overshoot pass;
+          // the ceiled ratio (10001) rejects it.
+          await expect(invoke(10002, 10001))
+            .to.be.revertedWithCustomError(roles, "ConditionViolation")
+            .withArgs(
+              ConditionViolationStatus.RatioAboveMax,
+              2, // WithinRatio node
+              anyValue,
+            );
+        });
+
+        it("still passes when the truncated ratio is genuinely within maxRatio", async () => {
+          const { allowFunction, invoke } = await loadFixture(setupTwoParams);
+
+          const compValue = encodeWithinRatioCompValue({
+            referencePluckIndex: 1,
+            referenceDecimals: 0,
+            relativePluckIndex: 0,
+            relativeDecimals: 0,
+            minRatio: 0,
+            maxRatio: 10000,
+          });
+
+          await allowFunction(
+            flattenCondition(matchesWithRatio([pluck(0), pluck(1)], compValue)),
+          );
+
+          // true ratio = 10000/10001 = 9999.0001 bps → ceil 10000 == cap:
+          // rounding up must not reject ratios genuinely within the bound
+          await expect(invoke(10000, 10001)).to.not.be.revert(ethers);
+        });
+
+        it("reverts when ratio falls below minRatio by less than 1 bps", async () => {
+          const { roles, allowFunction, invoke } =
+            await loadFixture(setupTwoParams);
+
+          const compValue = encodeWithinRatioCompValue({
+            referencePluckIndex: 1,
+            referenceDecimals: 0,
+            relativePluckIndex: 0,
+            relativeDecimals: 0,
+            minRatio: 10000, // 100%
+            maxRatio: 0,
+          });
+
+          await allowFunction(
+            flattenCondition(matchesWithRatio([pluck(0), pluck(1)], compValue)),
+          );
+
+          // true ratio = 99999/100000 = 9999.9 bps < 10000 floor.
+          // The floored ratio (9999) rejects; a ceiled ratio would round to
+          // 10000 and mask the shortfall.
+          await expect(invoke(99999, 100000))
+            .to.be.revertedWithCustomError(roles, "ConditionViolation")
+            .withArgs(
+              ConditionViolationStatus.RatioBelowMin,
+              2, // WithinRatio node
+              anyValue,
+            );
+        });
+      });
     });
 
     describe("decimal normalization", () => {

--- a/packages/evm/test/operators/28WithinAllowance.spec.ts
+++ b/packages/evm/test/operators/28WithinAllowance.spec.ts
@@ -1549,6 +1549,196 @@ describe("Operator - WithinAllowance", async () => {
       allowance = await roles.accruedAllowance(allowanceKey);
       expect(allowance.balance).to.equal(0);
     });
+
+    // Rounding must always favor the allowance: truncation in the price
+    // conversion (value * price / 1e18) rounds up, so consumption is never
+    // understated. Otherwise dust transfers convert to 0 consumed (bypassing
+    // exhausted allowances) and sub-unit truncation accumulates in favor of
+    // the spender across transactions.
+    describe("conversion rounding is conservative", () => {
+      it("dust amounts consume at least 1 unit when price < 1e18", async () => {
+        const { owner, roles, allowFunction, invoke } =
+          await loadFixture(setupOneParam);
+
+        const MockPricing = await ethers.getContractFactory("MockPricing");
+        // token worth 0.5 base units
+        const adapter = await MockPricing.deploy(5n * 10n ** 17n);
+
+        await setAllowance(await roles.connect(owner), allowanceKey, {
+          balance: 1_000_000n, // 1 unit in 6 decimals
+          period: 0,
+          refill: 0,
+          timestamp: 0,
+        });
+
+        await allowFunction([
+          {
+            parent: 0,
+            paramType: Encoding.AbiEncoded,
+            operator: Operator.Matches,
+            compValue: "0x",
+          },
+          {
+            parent: 0,
+            paramType: Encoding.Static,
+            operator: Operator.WithinAllowance,
+            compValue: encodeAllowanceCompValue({
+              allowanceKey,
+              adapter: await adapter.getAddress(),
+              targetDecimals: 6,
+              sourceDecimals: 18,
+            }),
+          },
+        ]);
+
+        // 1 wei of token: ceil(1 / 1e12) = 1, then ceil(1 * 0.5e18 / 1e18) = 1
+        await expect(invoke(1n)).to.not.be.revert(ethers);
+
+        const allowance = await roles.accruedAllowance(allowanceKey);
+        expect(allowance.balance).to.equal(999_999n);
+      });
+
+      it("dust amounts cannot pass an exhausted allowance", async () => {
+        const { owner, roles, allowFunction, invoke } =
+          await loadFixture(setupOneParam);
+
+        const MockPricing = await ethers.getContractFactory("MockPricing");
+        const adapter = await MockPricing.deploy(5n * 10n ** 17n);
+
+        await setAllowance(await roles.connect(owner), allowanceKey, {
+          balance: 0,
+          period: 0,
+          refill: 0,
+          timestamp: 0,
+        });
+
+        await allowFunction([
+          {
+            parent: 0,
+            paramType: Encoding.AbiEncoded,
+            operator: Operator.Matches,
+            compValue: "0x",
+          },
+          {
+            parent: 0,
+            paramType: Encoding.Static,
+            operator: Operator.WithinAllowance,
+            compValue: encodeAllowanceCompValue({
+              allowanceKey,
+              adapter: await adapter.getAddress(),
+              targetDecimals: 6,
+              sourceDecimals: 18,
+            }),
+          },
+        ]);
+
+        await expect(invoke(1n))
+          .to.be.revertedWithCustomError(roles, "ConditionViolation")
+          .withArgs(
+            ConditionViolationStatus.AllowanceExceeded,
+            1, // WithinAllowance node
+            anyValue,
+          );
+      });
+
+      it("truncation errors accumulate against the allowance, not the spender", async () => {
+        const { owner, roles, allowFunction, invoke } =
+          await loadFixture(setupOneParam);
+
+        const MockPricing = await ethers.getContractFactory("MockPricing");
+        // token worth 1.5 base units
+        const adapter = await MockPricing.deploy(15n * 10n ** 17n);
+
+        await setAllowance(await roles.connect(owner), allowanceKey, {
+          balance: 3n, // 3 whole base units
+          period: 0,
+          refill: 0,
+          timestamp: 0,
+        });
+
+        await allowFunction([
+          {
+            parent: 0,
+            paramType: Encoding.AbiEncoded,
+            operator: Operator.Matches,
+            compValue: "0x",
+          },
+          {
+            parent: 0,
+            paramType: Encoding.Static,
+            operator: Operator.WithinAllowance,
+            compValue: encodeAllowanceCompValue({
+              allowanceKey,
+              adapter: await adapter.getAddress(),
+              targetDecimals: 0, // whole base units
+              sourceDecimals: 18,
+            }),
+          },
+        ]);
+
+        // 1 token = 1.5 base units true value → consumes ceil(1.5) = 2
+        await expect(invoke(10n ** 18n)).to.not.be.revert(ethers);
+
+        let allowance = await roles.accruedAllowance(allowanceKey);
+        expect(allowance.balance).to.equal(1n);
+
+        // second token needs 2 > 1 remaining → rejected
+        // (with floor rounding this would consume 1 per tx, spending 4.5
+        // units of true value against a 3 unit allowance)
+        await expect(invoke(10n ** 18n))
+          .to.be.revertedWithCustomError(roles, "ConditionViolation")
+          .withArgs(
+            ConditionViolationStatus.AllowanceExceeded,
+            1, // WithinAllowance node
+            anyValue,
+          );
+      });
+
+      it("only rounds up on truncation, exact conversions stay exact", async () => {
+        const { owner, roles, allowFunction, invoke } =
+          await loadFixture(setupOneParam);
+
+        const MockPricing = await ethers.getContractFactory("MockPricing");
+        const adapter = await MockPricing.deploy(5n * 10n ** 17n); // 0.5
+
+        await setAllowance(await roles.connect(owner), allowanceKey, {
+          balance: 1_000_000n,
+          period: 0,
+          refill: 0,
+          timestamp: 0,
+        });
+
+        await allowFunction([
+          {
+            parent: 0,
+            paramType: Encoding.AbiEncoded,
+            operator: Operator.Matches,
+            compValue: "0x",
+          },
+          {
+            parent: 0,
+            paramType: Encoding.Static,
+            operator: Operator.WithinAllowance,
+            compValue: encodeAllowanceCompValue({
+              allowanceKey,
+              adapter: await adapter.getAddress(),
+              targetDecimals: 6,
+              sourceDecimals: 18,
+            }),
+          },
+        ]);
+
+        // 4 units (6 dec) * 0.5 = 2 exactly → no rounding
+        await expect(invoke(4n * 10n ** 12n)).to.not.be.revert(ethers);
+        let allowance = await roles.accruedAllowance(allowanceKey);
+        expect(allowance.balance).to.equal(999_998n);
+
+        // 5 units (6 dec) * 0.5 = 2.5 → rounds up to 3
+        await expect(invoke(5n * 10n ** 12n)).to.not.be.revert(ethers);
+        allowance = await roles.accruedAllowance(allowanceKey);
+        expect(allowance.balance).to.equal(999_995n);
+      });
+    });
   });
 
   describe("parameterized adapter", () => {


### PR DESCRIPTION
Rounding in value conversion consistently favored the caller. This PR flips every truncation to round towards the protocol, so allowances are hard maximums and ratio bounds are hard bounds.

## Allowance consumption rounded down (critical)

`PriceConversion.convert` floored `(amount * price) / 1e18`, understating consumption by up to 1 base unit per check. Two demonstrated consequences (see regression tests):

- **Dust bypass**: amounts converting to < 1 base unit consumed **zero**, so unlimited dust transfers passed through an exhausted allowance — the same class as the scale-down dust bug fixed earlier (`_ceilDiv` in `WithinAllowanceChecker`), reintroduced via the price adapter path whenever `price < 1e18` (any token worth less than one allowance base unit).
- **Cumulative truncation**: with coarse base decimals the loss is material — e.g. a $1.50 token against a whole-dollar USD allowance consumed $1 per 1-token transfer: $150 of real spend against a $100 allowance.

`convert()` now takes a rounding mode: `WithinAllowanceChecker` rounds up (truncation accumulates against the allowance), `WithinRatioChecker` behavior for amounts is unchanged.

## Ratio bounds floored (minor, ≤ 1 bps)

`WithinRatioChecker` floored the bps ratio for both bound checks, making `maxRatio` lenient by up to 1 bps: a true ratio up to `maxRatio + 1bps - 1wei` truncated down and passed. The `maxRatio` check now uses the ceiled ratio; `minRatio` keeps the floor (already strict). Truncation can no longer mask a bound violation in either direction.

Each fix comes with tests that fail without it, including exact-value tests proving no over-rejection is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvDSPnMhREXWx9wg296qP2