### PR TITLE
Fix Bitmask operand sizing when composed with Slice

### DIFF
--- a/packages/evm/contracts/core/evaluate/BitmaskChecker.sol
+++ b/packages/evm/contracts/core/evaluate/BitmaskChecker.sol
@@ -22,15 +22,16 @@ import {Status} from "../../types/Types.sol";
  *        - mask      N bytes; selects which bits of the operand are checked.
  *        - expected  N bytes; the required value of the selected bits.
  *
- *      Operand framing (passed via `inlined`):
- *        - inlined == true   Operand is a Static value (32 bytes at location)
+ *      Operand framing (passed via `inlined` and `size`):
+ *        - inlined == true   Operand is a Static value (`size` bytes at
+ *                            location; normally 32, or 1-32 after Slice)
  *        - inlined == false  Operand is a Dynamic value; `location` points at
  *                            the length-prefix word, content begins at
  *                            `location + 32` and `shift` indexes into content
  *                            (the prefix is not part of the addressable range)
  *
  *      Bounds: `shift + N` must not exceed the operand's actual byte length
- *      (32 for Static, the value of the length prefix for Dynamic). The
+ *      (`size` for Static, the value of the length prefix for Dynamic). The
  *      window is processed in 32-byte chunks; the trailing chunk is rinsed
  *      so unused tail bits cannot contribute to the comparison.
  *

--- a/packages/evm/contracts/core/evaluate/BitmaskChecker.sol
+++ b/packages/evm/contracts/core/evaluate/BitmaskChecker.sol
@@ -41,7 +41,8 @@ library BitmaskChecker {
         bytes calldata data,
         uint256 location,
         bytes memory compValue,
-        bool inlined
+        bool inlined,
+        uint256 size
     ) internal pure returns (Status) {
         uint256 shift = uint16(bytes2(compValue));
         uint256 n = (compValue.length - 2) / 2;
@@ -50,11 +51,12 @@ library BitmaskChecker {
          * Resolve the operand's encoded byte length so the compare cannot
          * bleed into trailing zero padding (or, for Dynamic operands sitting
          * mid-buffer, into the next ABI field).
-         *   - Static (inlined): 32 bytes inline at `location`.
+         *   - Static (inlined): `size` bytes inline at `location`. We rely on
+         *     the passed `size` because a static node may itself be sliced.
          *   - Dynamic: length prefix at `location`, content at `location + 32`.
          */
         uint256 start = location;
-        uint256 encodedLength = 32;
+        uint256 encodedLength = size;
         if (inlined == false) {
             if (start + 32 > data.length) {
                 return Status.BitmaskOverflow;

--- a/packages/evm/contracts/core/evaluate/ConditionEvaluator.sol
+++ b/packages/evm/contracts/core/evaluate/ConditionEvaluator.sol
@@ -113,7 +113,8 @@ library ConditionEvaluator {
                             data,
                             location,
                             condition.compValue,
-                            condition.inlined
+                            condition.inlined,
+                            condition.size
                         ),
                         location,
                         condition,

--- a/packages/evm/test/operators/13Slice.spec.ts
+++ b/packages/evm/test/operators/13Slice.spec.ts
@@ -284,6 +284,80 @@ describe("Operator - Slice", () => {
       const { balance } = await roles.accruedAllowance(allowanceKey);
       expect(balance).to.equal(70);
     });
+
+    it("frames a Bitmask child by the slice window", async () => {
+      const { roles, allowFunction, invoke } =
+        await loadFixture(setupDynamicParam);
+
+      // Slice the first 4 bytes, then Bitmask them. The Bitmask operand must be
+      // framed by the 4-byte window, not a full 32-byte word.
+      // compValue: shift(0x0000) + mask(0xffffffff) + expected(0xdeadbeef)
+      await allowFunction(
+        flattenCondition({
+          paramType: Encoding.AbiEncoded,
+          operator: Operator.Matches,
+          children: [
+            {
+              paramType: Encoding.Dynamic,
+              operator: Operator.Slice,
+              compValue: encodeCompValue(0, 4), // shift=0, size=4
+              children: [
+                {
+                  paramType: Encoding.Static,
+                  operator: Operator.Bitmask,
+                  compValue: "0x0000ffffffffdeadbeef",
+                },
+              ],
+            },
+          ],
+        }),
+        ExecutionOptions.Both,
+      );
+
+      await expect(invoke("0xdeadbeefcafe")).to.not.be.revert(ethers);
+      await expect(invoke("0xcafebabe1234"))
+        .to.be.revertedWithCustomError(roles, "ConditionViolation")
+        .withArgs(
+          ConditionViolationStatus.BitmaskNotAllowed,
+          anyValue,
+          anyValue,
+        );
+    });
+
+    it("reverts BitmaskOverflow when a Bitmask child's mask exceeds the slice window", async () => {
+      const { roles, allowFunction, invoke } =
+        await loadFixture(setupDynamicParam);
+
+      // Slice window is 4 bytes; the Bitmask mask starts at shift 1 and spans 4
+      // bytes (1 + 4 = 5 > 4), so it must overflow rather than read the 5th byte
+      // that lies outside the sliced window.
+      // compValue: shift(0x0001) + mask(0xffffffff) + expected(0x00000000)
+      await allowFunction(
+        flattenCondition({
+          paramType: Encoding.AbiEncoded,
+          operator: Operator.Matches,
+          children: [
+            {
+              paramType: Encoding.Dynamic,
+              operator: Operator.Slice,
+              compValue: encodeCompValue(0, 4), // shift=0, size=4
+              children: [
+                {
+                  paramType: Encoding.Static,
+                  operator: Operator.Bitmask,
+                  compValue: "0x0001ffffffff00000000",
+                },
+              ],
+            },
+          ],
+        }),
+        ExecutionOptions.Both,
+      );
+
+      await expect(invoke("0xdeadbeefcafe"))
+        .to.be.revertedWithCustomError(roles, "ConditionViolation")
+        .withArgs(ConditionViolationStatus.BitmaskOverflow, anyValue, anyValue);
+    });
   });
 
   describe("violation context", () => {

--- a/packages/evm/test/operators/13Slice.spec.ts
+++ b/packages/evm/test/operators/13Slice.spec.ts
@@ -31,7 +31,8 @@ function replaceBytes(data: string, byteOffset: number, replacement: string) {
 const connection = await network.create();
 const { ethers, networkHelpers } = connection;
 const { loadFixture } = networkHelpers;
-const { setupTestContract, setupDynamicParam } = createSetup(connection);
+const { setupTestContract, setupOneParam, setupDynamicParam } =
+  createSetup(connection);
 
 describe("Operator - Slice", () => {
   after(async () => {
@@ -357,6 +358,84 @@ describe("Operator - Slice", () => {
       await expect(invoke("0xdeadbeefcafe"))
         .to.be.revertedWithCustomError(roles, "ConditionViolation")
         .withArgs(ConditionViolationStatus.BitmaskOverflow, anyValue, anyValue);
+    });
+
+    it("frames Bitmask under a Slice of a static operand", async () => {
+      const { roles, allowFunction, invoke } = await loadFixture(setupOneParam);
+
+      await allowFunction(
+        flattenCondition({
+          paramType: Encoding.AbiEncoded,
+          operator: Operator.Matches,
+          children: [
+            {
+              paramType: Encoding.Static,
+              operator: Operator.Slice,
+              compValue: encodeCompValue(28, 4),
+              children: [
+                {
+                  paramType: Encoding.Static,
+                  operator: Operator.Bitmask,
+                  compValue: "0x0000ffffffffdeadbeef",
+                },
+              ],
+            },
+          ],
+        }),
+        ExecutionOptions.Both,
+      );
+
+      await expect(invoke(0xdeadbeef)).to.not.be.revert(ethers);
+      await expect(invoke(0xcafebabe))
+        .to.be.revertedWithCustomError(roles, "ConditionViolation")
+        .withArgs(
+          ConditionViolationStatus.BitmaskNotAllowed,
+          anyValue,
+          anyValue,
+        );
+    });
+
+    it("propagates the narrowed frame through nested slices", async () => {
+      const { roles, allowFunction, invoke } =
+        await loadFixture(setupDynamicParam);
+
+      await allowFunction(
+        flattenCondition({
+          paramType: Encoding.AbiEncoded,
+          operator: Operator.Matches,
+          children: [
+            {
+              paramType: Encoding.Dynamic,
+              operator: Operator.Slice,
+              compValue: encodeCompValue(1, 6),
+              children: [
+                {
+                  paramType: Encoding.Static,
+                  operator: Operator.Slice,
+                  compValue: encodeCompValue(0, 4),
+                  children: [
+                    {
+                      paramType: Encoding.Static,
+                      operator: Operator.Bitmask,
+                      compValue: "0x0000ffffffffdeadbeef",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+        ExecutionOptions.Both,
+      );
+
+      await expect(invoke("0xaadeadbeefbbcc")).to.not.be.revert(ethers);
+      await expect(invoke("0xaacafebabebbcc"))
+        .to.be.revertedWithCustomError(roles, "ConditionViolation")
+        .withArgs(
+          ConditionViolationStatus.BitmaskNotAllowed,
+          anyValue,
+          anyValue,
+        );
     });
   });
 


### PR DESCRIPTION
Fix Bitmask checks under Slice by respecting the slice’s narrowed byte size instead of assuming every static operand is 32 bytes.

This prevents masks from reading beyond the slice window and correctly returns BitmaskOverflow when the mask exceeds it.