### PR TITLE
Fix precision loss in WithinRatio comparisons

### DIFF
--- a/packages/evm/contracts/common/PriceConversion.sol
+++ b/packages/evm/contracts/common/PriceConversion.sol
@@ -33,7 +33,7 @@ library PriceConversion {
         address adapter,
         bytes memory params
     ) internal view returns (Status, uint256) {
-        (Status status, uint256 price) = _getPrice(adapter, params);
+        (Status status, uint256 price) = getPrice(adapter, params);
         if (status != Status.Ok) {
             return (status, 0);
         }
@@ -55,10 +55,10 @@ library PriceConversion {
      *
      */
 
-    function _getPrice(
+    function getPrice(
         address adapter,
         bytes memory params
-    ) private view returns (Status, uint256) {
+    ) internal view returns (Status, uint256) {
         if (adapter == address(0)) {
             return (Status.Ok, ONE);
         }

--- a/packages/evm/contracts/core/evaluate/WithinRatioChecker.sol
+++ b/packages/evm/contracts/core/evaluate/WithinRatioChecker.sol
@@ -12,9 +12,10 @@ import "../../types/Types.sol";
  * @notice Validates that a relative amount falls within a ratio range of a
  *         reference amount, with optional price adapter conversion.
  *
- * @dev Ratio is computed in basis points (10000 = 100%). Both amounts are read
- *      from pluckedValues by index, scaled to shared precision, optionally
- *      converted via price adapters, then compared against [minRatio, maxRatio].
+ * @dev Bounds are in basis points (10000 = 100%). Both amounts are read from
+ *      pluckedValues by index, scaled to shared precision, optionally priced
+ *      via adapters, then checked against [minRatio, maxRatio] using exact
+ *      cross-multiplied comparisons (no rounding; overflow reverts).
  *
  * @author gnosisguild
  */
@@ -71,24 +72,39 @@ library WithinRatioChecker {
         CompValue memory config = _unpack(compValue);
         (
             Status status,
-            uint256 referenceAmount,
-            uint256 relativeAmount
+            uint256 referenceAmountUp,
+            uint256 relativeAmountUp
         ) = _convert(config, pluckedValues);
         if (status != Status.Ok) {
             return status;
         }
 
         /*
-         *                 relativeAmount × priceRel
-         *   ratio (bps) = ───────────────────────── × 10,000
-         *                 referenceAmount × priceRef
+         * The naive formula looks like:
+         *
+         *                 relativeAmountUp
+         *   ratio (bps) = ───────────────── × 10,000   within [minRatio, maxRatio]
+         *                 referenceAmountUp
+         *
+         * It is equivalent to the following, which does no truncation:
+         *
+         *   below min ⇔ relativeAmountUp × 10,000 < referenceAmountUp × minRatio
+         *   above max ⇔ relativeAmountUp × 10,000 > referenceAmountUp × maxRatio
+         *
+         * A zero reference needs no special case: nothing is below min, and
+         * any nonzero relative amount exceeds a configured max. Checked
+         * arithmetic reverts if a multiplication overflows.
          */
-        uint256 ratio = (relativeAmount * BPS) / referenceAmount;
-
-        if (config.minRatio != 0 && ratio < config.minRatio) {
+        if (
+            config.minRatio != 0 &&
+            relativeAmountUp * BPS < referenceAmountUp * config.minRatio
+        ) {
             return Status.RatioBelowMin;
         }
-        if (config.maxRatio != 0 && ratio > config.maxRatio) {
+        if (
+            config.maxRatio != 0 &&
+            relativeAmountUp * BPS > referenceAmountUp * config.maxRatio
+        ) {
             return Status.RatioAboveMax;
         }
 
@@ -101,6 +117,10 @@ library WithinRatioChecker {
      *      1. Reads raw values from pluckedValues by index
      *      2. Scales both to the higher decimal precision
      *      3. Applies price adapters (if configured)
+     *
+     * @return status Ok, or the adapter failure status
+     * @return referenceAmount Reference amount, scaled up to common precision
+     * @return relativeAmount Relative amount, scaled up to common precision
      */
     function _convert(
         CompValue memory config,
@@ -133,19 +153,22 @@ library WithinRatioChecker {
         if (status != Status.Ok) return (status, 0, 0);
     }
 
+    /// @dev Returns the scaled value multiplied by the adapter price. The
+    ///      price's 10^18 factor is never divided out — it carries on both
+    ///      sides and cancels in the ratio comparison.
     function _scaleAndPrice(
         uint256 value,
         uint256 decimals,
         uint256 precision,
         address adapter,
         bytes memory params
-    ) private view returns (Status, uint256) {
-        return
-            PriceConversion.convert(
-                value * (10 ** (precision - decimals)),
-                adapter,
-                params
-            );
+    ) private view returns (Status status, uint256 price) {
+        (status, price) = PriceConversion.getPrice(adapter, params);
+        if (status != Status.Ok) {
+            return (status, 0);
+        }
+
+        return (Status.Ok, value * (10 ** (precision - decimals)) * price);
     }
 
     function _unpack(

--- a/packages/evm/test/operators/23WithinRatio.spec.ts
+++ b/packages/evm/test/operators/23WithinRatio.spec.ts
@@ -623,6 +623,167 @@ describe("Operator - WithinRatio", () => {
       });
     });
 
+    describe("conversion precision", () => {
+      it("rejects an above-max ratio before adapter conversion truncates a tiny amount", async () => {
+        const { roles, allowFunction, invoke } =
+          await loadFixture(setupTwoParams);
+
+        // We set the price to 1.999999999999999999, making the real ratio
+        // ~200%, and configure maxRatio at 100%. The check should reject, but
+        // converting each side separately truncates 1.999... to 1, so it sees
+        // 100% and wrongly accepts.
+
+        const MockPricing = await ethers.getContractFactory("MockPricing");
+        const relativeAdapter = await MockPricing.deploy(2n * 10n ** 18n - 1n);
+
+        const compValue = encodeWithinRatioCompValue({
+          relativeAdapter: await relativeAdapter.getAddress(),
+          referencePluckIndex: 2,
+          referenceDecimals: 0,
+          relativePluckIndex: 1,
+          relativeDecimals: 0,
+          minRatio: 0,
+          maxRatio: 10000,
+        });
+
+        await allowFunction(
+          flattenCondition(matchesWithRatio([pluck(1), pluck(2)], compValue)),
+        );
+
+        // Real ratio ~200% vs maxRatio 100% → must revert with RatioAboveMax
+        await expect(invoke(1, 1))
+          .to.be.revertedWithCustomError(roles, "ConditionViolation")
+          .withArgs(
+            ConditionViolationStatus.RatioAboveMax,
+            2, // WithinRatio node
+            anyValue,
+          );
+      });
+
+      it("rejects a ratio less than one bps above max", async () => {
+        const { roles, allowFunction, invoke } =
+          await loadFixture(setupTwoParams);
+
+        const compValue = encodeWithinRatioCompValue({
+          referencePluckIndex: 2,
+          referenceDecimals: 0,
+          relativePluckIndex: 1,
+          relativeDecimals: 0,
+          minRatio: 0,
+          maxRatio: 10000,
+        });
+
+        await allowFunction(
+          flattenCondition(matchesWithRatio([pluck(1), pluck(2)], compValue)),
+        );
+
+        // Real ratio 10002/10001 ≈ 100.00999...% — above max by less than one
+        // bps. A rounded-down ratio would floor to exactly 100% and wrongly
+        // accept.
+        await expect(invoke(10002, 10001))
+          .to.be.revertedWithCustomError(roles, "ConditionViolation")
+          .withArgs(
+            ConditionViolationStatus.RatioAboveMax,
+            2, // WithinRatio node
+            anyValue,
+          );
+      });
+
+      it("handles extreme values, failing closed beyond uint256 headroom", async () => {
+        const { allowFunction, invoke } = await loadFixture(setupTwoParams);
+
+        const compValue = encodeWithinRatioCompValue({
+          referencePluckIndex: 2,
+          referenceDecimals: 0,
+          relativePluckIndex: 1,
+          relativeDecimals: 0,
+          minRatio: 9000,
+          maxRatio: 11000,
+        });
+
+        await allowFunction(
+          flattenCondition(matchesWithRatio([pluck(1), pluck(2)], compValue)),
+        );
+
+        // Equal extreme values → ratio exactly 100%
+        await expect(invoke(10n ** 50n, 10n ** 50n)).to.not.be.revert(ethers);
+
+        // Beyond the supported magnitude the cross products overflow and the
+        // check reverts rather than wrapping around
+        await expect(invoke(ethers.MaxUint256, ethers.MaxUint256)).to.be.revert(
+          ethers,
+        );
+      });
+    });
+
+    describe("zero reference", () => {
+      it("reverts with RatioAboveMax when reference is zero and relative is not", async () => {
+        const { roles, allowFunction, invoke } =
+          await loadFixture(setupTwoParams);
+
+        const compValue = encodeWithinRatioCompValue({
+          referencePluckIndex: 2,
+          referenceDecimals: 0,
+          relativePluckIndex: 1,
+          relativeDecimals: 0,
+          minRatio: 0,
+          maxRatio: 10000,
+        });
+
+        await allowFunction(
+          flattenCondition(matchesWithRatio([pluck(1), pluck(2)], compValue)),
+        );
+
+        // Any nonzero relative amount exceeds a max bound on a zero reference
+        await expect(invoke(1, 0))
+          .to.be.revertedWithCustomError(roles, "ConditionViolation")
+          .withArgs(
+            ConditionViolationStatus.RatioAboveMax,
+            2, // WithinRatio node
+            anyValue,
+          );
+      });
+
+      it("passes when both amounts are zero", async () => {
+        const { allowFunction, invoke } = await loadFixture(setupTwoParams);
+
+        const compValue = encodeWithinRatioCompValue({
+          referencePluckIndex: 2,
+          referenceDecimals: 0,
+          relativePluckIndex: 1,
+          relativeDecimals: 0,
+          minRatio: 9000,
+          maxRatio: 11000,
+        });
+
+        await allowFunction(
+          flattenCondition(matchesWithRatio([pluck(1), pluck(2)], compValue)),
+        );
+
+        await expect(invoke(0, 0)).to.not.be.revert(ethers);
+      });
+
+      it("passes a zero reference when only a min bound is set", async () => {
+        const { allowFunction, invoke } = await loadFixture(setupTwoParams);
+
+        const compValue = encodeWithinRatioCompValue({
+          referencePluckIndex: 2,
+          referenceDecimals: 0,
+          relativePluckIndex: 1,
+          relativeDecimals: 0,
+          minRatio: 1000,
+          maxRatio: 0,
+        });
+
+        await allowFunction(
+          flattenCondition(matchesWithRatio([pluck(1), pluck(2)], compValue)),
+        );
+
+        // min bound is vacuous against a zero reference
+        await expect(invoke(5, 0)).to.not.be.revert(ethers);
+      });
+    });
+
     describe("adapter call safety", () => {
       it("reverts with PricingAdapterNotAContract when reference adapter not deployed", async () => {
         const { roles, allowFunction, invoke } =


### PR DESCRIPTION
Fixes a precision bug in `WithinRatio` where price-converted amounts were rounded before their ratio was calculated. It also handles zero reference amounts without division by zero.

The checker now retains adapter prices at full precision and compares ratio bounds through cross-multiplication, avoiding truncation during price conversion and ratio calculation.

Adds tests covering WithinRatio precision cases