### PR TITLE
Fix dust loss in WithinAllowance conversions

### DIFF
--- a/packages/evm/contracts/common/PriceConversion.sol
+++ b/packages/evm/contracts/common/PriceConversion.sol
@@ -9,37 +9,16 @@ import "../types/Types.sol";
 
 /**
  * @title PriceConversion
- * @notice Library for applying exchange rate conversion via IPricing adapters.
+ * @notice Library for retrieving exchange rates from IPricing adapters.
  *
- * @dev Converts amounts using an external pricing adapter. The adapter returns
- *      a price with 18 decimals precision. Decimal scaling should be handled
- *      by the caller.
+ * @dev The adapter returns a price with 18 decimals precision. Applying that
+ *      price and any decimal scaling is handled by the caller.
  *
  * @author gnosisguild
  */
 library PriceConversion {
     uint256 private constant PRICE_DECIMALS = 18;
     uint256 private constant ONE = 10 ** PRICE_DECIMALS;
-
-    /**
-     * @notice Applies exchange rate conversion to an amount.
-     * @param amount The amount to convert
-     * @param adapter Price adapter address
-     * @return status Ok or error status from adapter
-     * @return result Amount multiplied by price and divided by 10^18
-     */
-    function convert(
-        uint256 amount,
-        address adapter,
-        bytes memory params
-    ) internal view returns (Status, uint256) {
-        (Status status, uint256 price) = getPrice(adapter, params);
-        if (status != Status.Ok) {
-            return (status, 0);
-        }
-
-        return (Status.Ok, (amount * price) / ONE);
-    }
 
     /**
      * @dev Safely invokes pricing adapter via staticcall.

--- a/packages/evm/contracts/common/PriceLoader.sol
+++ b/packages/evm/contracts/common/PriceLoader.sol
@@ -8,7 +8,7 @@ import "../periphery/interfaces/IPricing.sol";
 import "../types/Types.sol";
 
 /**
- * @title PriceConversion
+ * @title PriceLoader
  * @notice Library for retrieving exchange rates from IPricing adapters.
  *
  * @dev The adapter returns a price with 18 decimals precision. Applying that
@@ -16,7 +16,7 @@ import "../types/Types.sol";
  *
  * @author gnosisguild
  */
-library PriceConversion {
+library PriceLoader {
     uint256 private constant PRICE_DECIMALS = 18;
     uint256 private constant ONE = 10 ** PRICE_DECIMALS;
 
@@ -34,7 +34,7 @@ library PriceConversion {
      *
      */
 
-    function getPrice(
+    function load(
         address adapter,
         bytes memory params
     ) internal view returns (Status, uint256) {

--- a/packages/evm/contracts/core/evaluate/WithinAllowanceChecker.sol
+++ b/packages/evm/contracts/core/evaluate/WithinAllowanceChecker.sol
@@ -53,34 +53,26 @@ library WithinAllowanceChecker {
         );
 
         // 2. Convert and scale up the input value
-        uint256 scaledInput;
-        (status, scaledInput) = _convertAndScaleUpInputValue(value, compValue);
+        (status, value) = _convertAndScaleInput(value, compValue);
         if (status != Status.Ok) {
             return (status, consumptions);
         }
 
-        // 3. Scale the stored values to the same precision as the input
-        uint256 scaledConsumed = _scaleUpBalanceValue(
-            consumption.consumed,
-            compValue
-        );
-        uint256 scaledBalance = _scaleUpBalanceValue(
-            consumption.balance,
-            compValue
-        );
-        uint256 nextScaledConsumed = scaledConsumed + scaledInput;
+        // 3. Scale the stored values to the input's precision, and add the
+        //    input to the consumed amount
+        uint256 balance = _scaleBalance(consumption.balance, compValue);
+        uint256 consumed = _scaleBalance(consumption.consumed, compValue) +
+            value;
 
         // 4. Check the allowance at highest level precision
-        if (nextScaledConsumed > scaledBalance) {
+        if (consumed > balance) {
             return (Status.AllowanceExceeded, consumptions);
         }
 
         // 5. Scale consumption down to the allowance's balance precision,
         //    and round up the division. Fits uint128: the check above caps
         //    it at balance.
-        consumption.consumed = uint128(
-            _scaleDownBalanceValue(nextScaledConsumed, compValue)
-        );
+        consumption.consumed = uint128(_unscale(consumed, compValue));
 
         // 6. Return updated list
         return (
@@ -89,39 +81,11 @@ library WithinAllowanceChecker {
         );
     }
 
-    function _findConsumption(
-        Consumption[] memory consumptions,
-        bytes32 allowanceKey
-    ) private view returns (Consumption memory consumption, uint256 index) {
-        for (; index < consumptions.length; ++index) {
-            if (consumptions[index].allowanceKey == allowanceKey) break;
-        }
-
-        if (index < consumptions.length) {
-            consumption = consumptions[index];
-            return (
-                Consumption(
-                    allowanceKey,
-                    consumption.balance,
-                    consumption.consumed,
-                    consumption.timestamp
-                ),
-                index
-            );
-        }
-
-        (uint128 balance, uint64 timestamp) = AllowanceLoader.accrue(
-            allowanceKey,
-            uint64(block.timestamp)
-        );
-        return (Consumption(allowanceKey, balance, 0, timestamp), index);
-    }
-
     /**
-     * @dev Converts and scales an input value to the highest decimal precision,
-     *      retaining the price's 18-decimal factor.
+     * @dev Scales an input value to the highest decimal precision, applying
+     *      the price and retaining its 18-decimal factor.
      */
-    function _convertAndScaleUpInputValue(
+    function _convertAndScaleInput(
         uint256 value,
         bytes memory compValue
     ) private view returns (Status status, uint256) {
@@ -159,8 +123,11 @@ library WithinAllowanceChecker {
         return (Status.Ok, value * (10 ** (precision - inputDecimals)) * price);
     }
 
-    /// @dev Scales a balance-decimal value to the comparison precision.
-    function _scaleUpBalanceValue(
+    /**
+     * @dev Scales a balance-denominated value to the comparison precision.
+     *      Includes the price's 1e18 scale so comparison happens without loss.
+     */
+    function _scaleBalance(
         uint256 value,
         bytes memory compValue
     ) private pure returns (uint256) {
@@ -172,16 +139,45 @@ library WithinAllowanceChecker {
     }
 
     /**
-     * @dev Scales a comparison value down to balance decimals, rounding up.
-     *      Scaling the balance value 1 up produces the exact inverse factor:
-     *      the retained 1e18 price precision and, when input decimals are
-     *      higher, the additional decimal scale.
+     * @dev Scales a comparison value down to balance decimals.
+     *      Scaling 1 produces the exact inverse factor required to unscale.
+     *
+     *      Important: since this is the value used in allowance accrual,
+     *      we round up dust.
      */
-    function _scaleDownBalanceValue(
+    function _unscale(
         uint256 value,
         bytes memory compValue
     ) private pure returns (uint256) {
-        return _ceilDiv(value, _scaleUpBalanceValue(1, compValue));
+        return _ceilDiv(value, _scaleBalance(1, compValue));
+    }
+
+    function _findConsumption(
+        Consumption[] memory consumptions,
+        bytes32 allowanceKey
+    ) private view returns (Consumption memory consumption, uint256 index) {
+        for (; index < consumptions.length; ++index) {
+            if (consumptions[index].allowanceKey == allowanceKey) break;
+        }
+
+        if (index < consumptions.length) {
+            consumption = consumptions[index];
+            return (
+                Consumption(
+                    allowanceKey,
+                    consumption.balance,
+                    consumption.consumed,
+                    consumption.timestamp
+                ),
+                index
+            );
+        }
+
+        (uint128 balance, uint64 timestamp) = AllowanceLoader.accrue(
+            allowanceKey,
+            uint64(block.timestamp)
+        );
+        return (Consumption(allowanceKey, balance, 0, timestamp), index);
     }
 
     function _unpack(

--- a/packages/evm/contracts/core/evaluate/WithinAllowanceChecker.sol
+++ b/packages/evm/contracts/core/evaluate/WithinAllowanceChecker.sol
@@ -15,9 +15,9 @@ import {Consumption} from "../../types/Allowance.sol";
  * @title WithinAllowanceChecker
  * @notice Validates allowance consumption with optional amount conversion.
  *
- * @dev Checks if a value is within an allowance and consumes it. The value is
- *      normalized to the allowance's base denomination via decimal scaling
- *      and/or exchange rate conversion.
+ * @dev Checks if a value is within an allowance and consumes it. Values are
+ *      compared at the highest required precision and only scaled back down
+ *      when the consumption is recorded.
  *
  *      The `consumptions` array is treated as immutable. If consumption occurs,
  *      a new array is allocated and returned (Copy-on-Write).
@@ -25,6 +25,20 @@ import {Consumption} from "../../types/Allowance.sol";
  * @author gnosisguild
  */
 library WithinAllowanceChecker {
+    /**
+     * CompValue Layout (32, 34, 54, or 54+ bytes):
+     * ┌─────────────────────────┬──────────┬──────────┬─────────────────────┬─────────────────────┐
+     * │      allowanceKey       │ balance  │  input   │       adapter       │    adapterParams    │
+     * │        (bytes32)        │ decimals │ decimals │      (address)      │       (bytes)       │
+     * ├─────────────────────────┼──────────┼──────────┼─────────────────────┼─────────────────────┤
+     * │         0 - 31          │    32    │    33    │       34 - 53       │        54+          │
+     * └─────────────────────────┴──────────┴──────────┴─────────────────────┴─────────────────────┘
+     *                           └── optional ─────────┴───── optional ──────┴──── optional ───────┘
+     *
+     * balanceDecimals: decimals used to track the allowance balance
+     * inputDecimals: decimals of the value being checked
+     * adapterParams: optional trailing bytes passed to IPricing.getPrice(params)
+     */
     function check(
         Consumption[] memory consumptions,
         uint256 value,
@@ -32,106 +46,92 @@ library WithinAllowanceChecker {
     ) internal view returns (Status status, Consumption[] memory) {
         bytes32 allowanceKey = bytes32(compValue);
 
-        // 1. Convert value to base denomination
-        (status, value) = _convert(value, compValue);
+        // 1. Find the current consumption or load its accrued allowance
+        (Consumption memory consumption, uint256 index) = _findConsumption(
+            consumptions,
+            allowanceKey
+        );
+
+        // 2. Convert and scale up the input value
+        uint256 scaledInput;
+        (status, scaledInput) = _convertAndScaleUpInputValue(value, compValue);
         if (status != Status.Ok) {
             return (status, consumptions);
         }
 
-        // 2. Find in list
-        uint256 index;
-        for (; index < consumptions.length; ++index) {
-            if (consumptions[index].allowanceKey == allowanceKey) break;
-        }
+        // 3. Scale the stored values to the same precision as the input
+        uint256 scaledConsumed = _scaleUpBalanceValue(
+            consumption.consumed,
+            compValue
+        );
+        uint256 scaledBalance = _scaleUpBalanceValue(
+            consumption.balance,
+            compValue
+        );
+        uint256 nextScaledConsumed = scaledConsumed + scaledInput;
 
-        // 3. Copy existing or load from storage
-        Consumption memory consumption;
-        if (index < consumptions.length) {
-            consumption = Consumption(
-                allowanceKey,
-                consumptions[index].balance,
-                consumptions[index].consumed,
-                consumptions[index].timestamp
-            );
-        } else {
-            (uint128 balance, uint64 timestamp) = AllowanceLoader.accrue(
-                allowanceKey,
-                uint64(block.timestamp)
-            );
-            consumption = Consumption(allowanceKey, balance, 0, timestamp);
-        }
-
-        // 4. Check overflow before consuming
-        if (consumption.consumed + value > type(uint128).max) {
-            return (Status.AllowanceValueOverflow, consumptions);
-        }
-
-        // 5. Consume
-        consumption.consumed += uint128(value);
-
-        // 6. Check balance
-        if (consumption.consumed > consumption.balance) {
+        // 4. Check the allowance at highest level precision
+        if (nextScaledConsumed > scaledBalance) {
             return (Status.AllowanceExceeded, consumptions);
         }
 
-        // 7. Return updated list
+        // 5. Scale consumption down to the allowance's balance precision,
+        //    and round up the division. Fits uint128: the check above caps
+        //    it at balance.
+        consumption.consumed = uint128(
+            _scaleDownBalanceValue(nextScaledConsumed, compValue)
+        );
+
+        // 6. Return updated list
         return (
             Status.Ok,
             ConsumptionList.copyOnWrite(consumptions, consumption, index)
         );
     }
 
+    function _findConsumption(
+        Consumption[] memory consumptions,
+        bytes32 allowanceKey
+    ) private view returns (Consumption memory consumption, uint256 index) {
+        for (; index < consumptions.length; ++index) {
+            if (consumptions[index].allowanceKey == allowanceKey) break;
+        }
+
+        if (index < consumptions.length) {
+            consumption = consumptions[index];
+            return (
+                Consumption(
+                    allowanceKey,
+                    consumption.balance,
+                    consumption.consumed,
+                    consumption.timestamp
+                ),
+                index
+            );
+        }
+
+        (uint128 balance, uint64 timestamp) = AllowanceLoader.accrue(
+            allowanceKey,
+            uint64(block.timestamp)
+        );
+        return (Consumption(allowanceKey, balance, 0, timestamp), index);
+    }
+
     /**
-     * @dev Normalizes a value to the allowance's base denomination.
-     *
-     *      Calculates the final amount via decimal scaling and optionally
-     *      an exchange rate (via price adapter). Scaling is possible without
-     *      an adapter by providing both base and param decimals.
-     *
-     * @param value The raw amount to be converted.
-     * @param compValue Configuration bytes containing decimals and adapter.
-     * @return status Result of the conversion (Ok or price adapter error).
-     * @return converted Normalized amount in the allowance's base decimals.
+     * @dev Converts and scales an input value to the highest decimal precision,
+     *      retaining the price's 18-decimal factor.
      */
-    function _convert(
+    function _convertAndScaleUpInputValue(
         uint256 value,
         bytes memory compValue
-    ) private view returns (Status, uint256) {
-        /**
-         * CompValue Layout (32, 34, 54, or 54+ bytes):
-         * ┌─────────────────────────┬──────────┬──────────┬─────────────────────┬─────────────────────┐
-         * │      allowanceKey       │   base   │  param   │       adapter       │    adapterParams    │
-         * │        (bytes32)        │ decimals │ decimals │      (address)      │       (bytes)       │
-         * ├─────────────────────────┼──────────┼──────────┼─────────────────────┼─────────────────────┤
-         * │         0 - 31          │    32    │    33    │       34 - 53       │        54+          │
-         * └─────────────────────────┴──────────┴──────────┴─────────────────────┴─────────────────────┘
-         *                           └── optional ─────────┴───── optional ──────┴──── optional ───────┘
-         *
-         * baseDecimals: decimals of the allowance unit  (how it's accounted)
-         * paramDecimals: decimals of the parameter value (from calldata)
-         * adapterParams: optional trailing bytes passed to IPricing.getPrice(params)
-         */
-
+    ) private view returns (Status status, uint256) {
+        // A 32-byte compValue contains only the allowance key, so the input is
+        // already denominated in balance units and needs no conversion.
         if (compValue.length == 32) {
             return (Status.Ok, value);
         }
 
-        uint256 baseDecimals = uint8(compValue[32]);
-        uint256 paramDecimals = uint8(compValue[33]);
-
-        // Scale decimals
-        if (baseDecimals >= paramDecimals) {
-            /*
-             * Scale Up
-             */
-            value = value * (10 ** (baseDecimals - paramDecimals));
-        } else {
-            /*
-             * Scale Down
-             * round up - dust amounts always consume at least 1 in target precision
-             */
-            value = _ceilDiv(value, 10 ** (paramDecimals - baseDecimals));
-        }
+        (, uint256 inputDecimals, uint256 precision) = _unpack(compValue);
 
         address adapter;
         if (compValue.length > 34) {
@@ -150,7 +150,56 @@ library WithinAllowanceChecker {
             }
         }
 
-        return PriceConversion.convert(value, adapter, params);
+        uint256 price;
+        (status, price) = PriceConversion.getPrice(adapter, params);
+        if (status != Status.Ok) {
+            return (status, 0);
+        }
+
+        return (Status.Ok, value * (10 ** (precision - inputDecimals)) * price);
+    }
+
+    /// @dev Scales a balance-decimal value to the comparison precision.
+    function _scaleUpBalanceValue(
+        uint256 value,
+        bytes memory compValue
+    ) private pure returns (uint256) {
+        if (compValue.length == 32) return value;
+
+        (uint256 balanceDecimals, , uint256 precision) = _unpack(compValue);
+
+        return value * (10 ** (precision - balanceDecimals)) * 1e18;
+    }
+
+    /**
+     * @dev Scales a comparison value down to balance decimals, rounding up.
+     *      Scaling the balance value 1 up produces the exact inverse factor:
+     *      the retained 1e18 price precision and, when input decimals are
+     *      higher, the additional decimal scale.
+     */
+    function _scaleDownBalanceValue(
+        uint256 value,
+        bytes memory compValue
+    ) private pure returns (uint256) {
+        return _ceilDiv(value, _scaleUpBalanceValue(1, compValue));
+    }
+
+    function _unpack(
+        bytes memory compValue
+    )
+        private
+        pure
+        returns (
+            uint256 balanceDecimals,
+            uint256 inputDecimals,
+            uint256 precision
+        )
+    {
+        balanceDecimals = uint8(compValue[32]);
+        inputDecimals = uint8(compValue[33]);
+        precision = balanceDecimals > inputDecimals
+            ? balanceDecimals
+            : inputDecimals;
     }
 
     /// @dev Ceiling division. Returns 0 for 0, otherwise ⌈a / b⌉.

--- a/packages/evm/contracts/core/evaluate/WithinAllowanceChecker.sol
+++ b/packages/evm/contracts/core/evaluate/WithinAllowanceChecker.sol
@@ -6,7 +6,7 @@ pragma solidity >=0.8.17 <0.9.0;
 
 import "../../common/AllowanceLoader.sol";
 import "../../common/ConsumptionList.sol";
-import "../../common/PriceConversion.sol";
+import "../../common/PriceLoader.sol";
 import "../../types/Types.sol";
 
 import {Consumption} from "../../types/Allowance.sol";
@@ -151,7 +151,7 @@ library WithinAllowanceChecker {
         }
 
         uint256 price;
-        (status, price) = PriceConversion.getPrice(adapter, params);
+        (status, price) = PriceLoader.load(adapter, params);
         if (status != Status.Ok) {
             return (status, 0);
         }

--- a/packages/evm/contracts/core/evaluate/WithinRatioChecker.sol
+++ b/packages/evm/contracts/core/evaluate/WithinRatioChecker.sol
@@ -4,7 +4,7 @@
 // Converts to LGPL-3.0-or-later on 2030-03-01
 pragma solidity >=0.8.17 <0.9.0;
 
-import "../../common/PriceConversion.sol";
+import "../../common/PriceLoader.sol";
 import "../../types/Types.sol";
 
 /**
@@ -163,7 +163,7 @@ library WithinRatioChecker {
         address adapter,
         bytes memory params
     ) private view returns (Status status, uint256 price) {
-        (status, price) = PriceConversion.getPrice(adapter, params);
+        (status, price) = PriceLoader.load(adapter, params);
         if (status != Status.Ok) {
             return (status, 0);
         }

--- a/packages/evm/contracts/types/Authorization.sol
+++ b/packages/evm/contracts/types/Authorization.sol
@@ -37,7 +37,8 @@ enum Status {
     PricingAdapterInvalidResult,
     PricingAdapterZeroPrice,
     AllowanceExceeded,
-    /// Converted allowance value exceeds uint128 max
+    /// No longer emitted: full-precision comparison reports AllowanceExceeded
+    /// instead. Kept to preserve status codes.
     AllowanceValueOverflow,
     CalldataOverflow,
     RatioBelowMin,

--- a/packages/evm/test/operators/28WithinAllowance.spec.ts
+++ b/packages/evm/test/operators/28WithinAllowance.spec.ts
@@ -328,45 +328,6 @@ describe("Operator - WithinAllowance", async () => {
 
       await expect(invoke(9000)).to.not.be.revert(ethers);
     });
-    it("reverts when value exceeds uint128 max", async () => {
-      const { owner, roles, allowFunction, invoke } =
-        await loadFixture(setupOneParam);
-
-      const allowanceKey = hexlify(randomBytes(32));
-
-      await setAllowance(await roles.connect(owner), allowanceKey, {
-        balance: 1000,
-        period: 0,
-        refill: 0,
-        timestamp: 0,
-      });
-
-      await allowFunction([
-        {
-          parent: 0,
-          paramType: Encoding.AbiEncoded,
-          operator: Operator.Matches,
-          compValue: "0x",
-        },
-        {
-          parent: 0,
-          paramType: Encoding.Static,
-          operator: Operator.WithinAllowance,
-          compValue: defaultAbiCoder.encode(["bytes32"], [allowanceKey]),
-        },
-      ]);
-
-      // uint128 max + 1
-      const exceedsUint128 = 2n ** 128n;
-
-      await expect(invoke(exceedsUint128))
-        .to.be.revertedWithCustomError(roles, "ConditionViolation")
-        .withArgs(
-          ConditionViolationStatus.AllowanceValueOverflow,
-          1, // WithinAllowance node
-          anyValue,
-        );
-    });
   });
 
   describe("WithinAllowance - Consumption", async () => {

--- a/packages/evm/test/operators/28WithinAllowance.spec.ts
+++ b/packages/evm/test/operators/28WithinAllowance.spec.ts
@@ -328,6 +328,46 @@ describe("Operator - WithinAllowance", async () => {
 
       await expect(invoke(9000)).to.not.be.revert(ethers);
     });
+    it("fails a check with AllowanceExceeded when value exceeds uint128 max", async () => {
+      const { owner, roles, allowFunction, invoke } =
+        await loadFixture(setupOneParam);
+
+      const allowanceKey = hexlify(randomBytes(32));
+
+      await setAllowance(await roles.connect(owner), allowanceKey, {
+        balance: 1000,
+        period: 0,
+        refill: 0,
+        timestamp: 0,
+      });
+
+      await allowFunction([
+        {
+          parent: 0,
+          paramType: Encoding.AbiEncoded,
+          operator: Operator.Matches,
+          compValue: "0x",
+        },
+        {
+          parent: 0,
+          paramType: Encoding.Static,
+          operator: Operator.WithinAllowance,
+          compValue: defaultAbiCoder.encode(["bytes32"], [allowanceKey]),
+        },
+      ]);
+
+      // uint128 max + 1: no longer a dedicated AllowanceValueOverflow, since
+      // full-precision comparison classifies it as exceeding any balance
+      const exceedsUint128 = 2n ** 128n;
+
+      await expect(invoke(exceedsUint128))
+        .to.be.revertedWithCustomError(roles, "ConditionViolation")
+        .withArgs(
+          ConditionViolationStatus.AllowanceExceeded,
+          1, // WithinAllowance node
+          anyValue,
+        );
+    });
   });
 
   describe("WithinAllowance - Consumption", async () => {
@@ -2297,6 +2337,7 @@ describe("Operator - WithinAllowance", async () => {
           },
         ]);
       });
+
     });
 
     it("reverts LeafNodeCannotHaveChildren when WithinAllowance has children", async () => {

--- a/packages/evm/test/operators/28WithinAllowance.spec.ts
+++ b/packages/evm/test/operators/28WithinAllowance.spec.ts
@@ -953,6 +953,59 @@ describe("Operator - WithinAllowance", async () => {
     const allowanceKey =
       "0x0000000000000000000000000000000000000000000000000000000000000001";
 
+    it("price-converted dust rounds up and consumes 1 in target precision", async () => {
+      const { owner, roles, allowFunction, invoke } =
+        await loadFixture(setupOneParam);
+
+      const MockPricing = await ethers.getContractFactory("MockPricing");
+
+      /*
+       * Spend: 1 source unit (0 decimals). Price: 0.5, encoded as 5e17 with
+       * 18 decimals. Allowance: 2 target units (0 decimals).
+       *
+       * Each spend converts to 1 * 5e17 / 1e18 = 0.5 target units and must
+       * consume ceil(0.5) = 1: balance goes 2 → 1 → 0, then reverts.
+       * Floored, it would consume 0 and let unlimited dust spends through.
+       */
+      const adapter = await MockPricing.deploy(5n * 10n ** 17n); // 0.5x
+
+      await setAllowance(await roles.connect(owner), allowanceKey, {
+        balance: 2,
+        period: 0,
+        refill: 0,
+        timestamp: 0,
+      });
+
+      await allowFunction([
+        {
+          parent: 0,
+          paramType: Encoding.AbiEncoded,
+          operator: Operator.Matches,
+          compValue: "0x",
+        },
+        {
+          parent: 0,
+          paramType: Encoding.Static,
+          operator: Operator.WithinAllowance,
+          compValue: encodeAllowanceCompValue({
+            allowanceKey,
+            adapter: await adapter.getAddress(),
+          }),
+        },
+      ]);
+
+      expect((await roles.accruedAllowance(allowanceKey)).balance).to.equal(2);
+      // each spend converts to 0.5, and consumes ceil(0.5) = 1, never 0
+      await expect(invoke(1)).to.not.be.revert(ethers);
+      expect((await roles.accruedAllowance(allowanceKey)).balance).to.equal(1);
+      await expect(invoke(1)).to.not.be.revert(ethers);
+      expect((await roles.accruedAllowance(allowanceKey)).balance).to.equal(0);
+
+      await expect(invoke(1))
+        .to.be.revertedWithCustomError(roles, "ConditionViolation")
+        .withArgs(ConditionViolationStatus.AllowanceExceeded, 1, anyValue);
+    });
+
     // base=12, param=6: scale up by 10^6
     // 1000 units (6 dec) → converted = 1000e6 * 1e18 * 1e12 / 1e24 = 1000e12 (12 dec)
     it("param(6) → base(12): consumes correctly", async () => {

--- a/packages/sdk/src/main/types.ts
+++ b/packages/sdk/src/main/types.ts
@@ -103,6 +103,7 @@ export enum Status {
   BitmaskNotAllowed,
   CustomConditionViolation,
   AllowanceExceeded,
+  /** No longer emitted: full-precision comparison reports AllowanceExceeded instead. Kept to preserve status codes. */
   AllowanceValueOverflow,
   /** Payload overflow found by Checker */
   CalldataOverflow,


### PR DESCRIPTION
## Problem

`WithinAllowance` previously scaled the input to the balance precision before applying the adapter price. That conversion could depending on direction truncate the result, allowing fractional consumption to become zero.

## Solution

Scale inputs and balances up to their highest shared precision before comparing them, avoiding precision loss during allowance checks.

After a successful check, scale consumption back down to balance decimals, AND ROUND UP, ensuring dust is always accounted for