### PR TITLE
Integrity Hardening

### DIFF
--- a/packages/evm/contracts/__test__/mocks/MockConditionEvaluator.sol
+++ b/packages/evm/contracts/__test__/mocks/MockConditionEvaluator.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 GG DAO LLC
+// Zodiac Roles Modifier v3
+// Converts to LGPL-3.0-or-later on 2030-03-01
+pragma solidity >=0.8.17 <0.9.0;
+
+import "../../core/evaluate/ConditionEvaluator.sol";
+import "../../types/Types.sol";
+
+contract MockConditionEvaluator is IRolesError {
+    function evaluate(
+        bytes calldata data,
+        Operator op
+    ) external view returns (Status) {
+        Condition memory condition;
+        condition.index = 7;
+        condition.operator = op;
+
+        Consumption[] memory consumptions = new Consumption[](0);
+        Context memory context = Context({
+            to: address(this),
+            value: 0,
+            operation: Operation.Call,
+            pluckedValues: new bytes32[](0),
+            pluckedLocations: new uint256[](0)
+        });
+
+        return
+            ConditionEvaluator
+                .evaluate(data, 0, condition, consumptions, context)
+                .status;
+    }
+}

--- a/packages/evm/contracts/core/evaluate/ConditionEvaluator.sol
+++ b/packages/evm/contracts/core/evaluate/ConditionEvaluator.sol
@@ -75,8 +75,9 @@ library ConditionEvaluator {
                         consumptions,
                         context
                     );
-            } else {
-                // ZipSome or ZipEvery
+            } else if (
+                operator == Operator.ZipSome || operator == Operator.ZipEvery
+            ) {
                 return
                     _zipIterator(
                         data,
@@ -155,8 +156,7 @@ library ConditionEvaluator {
                         condition,
                         consumptions
                     );
-            } else {
-                // Custom
+            } else if (operator == Operator.Custom) {
                 return
                     _result(
                         CustomConditionChecker.check(
@@ -175,6 +175,8 @@ library ConditionEvaluator {
                     );
             }
         }
+
+        revert IRolesError.UnsupportedOperator(condition.index);
     }
 
     function _matches(

--- a/packages/evm/contracts/core/serialize/ConditionStorer.sol
+++ b/packages/evm/contracts/core/serialize/ConditionStorer.sol
@@ -13,7 +13,7 @@ import "../../types/Types.sol";
 
 /**
  * @title ConditionStorer
- * @notice Validates and stores condition trees in immutable storage.
+ * @notice Packs condition trees and stores packed buffers in immutable storage.
  *
  * @author gnosisguild
  */
@@ -34,7 +34,7 @@ library ConditionStorer {
     /**
      * @notice Stores a pre-packed condition buffer.
      *
-     * @param buffer The packed condition buffer (from pack()).
+     * @param buffer The packed condition buffer.
      * @param options Execution options (Send, DelegateCall, Both, None).
      * @return scopeConfig Packed scope config (options << 160 | pointer).
      */

--- a/packages/evm/contracts/core/serialize/Integrity.sol
+++ b/packages/evm/contracts/core/serialize/Integrity.sol
@@ -16,17 +16,49 @@ import "../../types/Types.sol";
  * @author gnosisguild
  */
 library Integrity {
+    uint256 private constant MAX_CONDITION_COUNT = type(uint16).max;
+    uint256 private constant MAX_CHILD_COUNT = (1 << 10) - 1;
+    uint256 private constant MAX_INLINED_SIZE = (1 << 13) - 1;
+    uint256 private constant MAX_COMP_VALUE_LENGTH = type(uint16).max;
+
     function enforce(ConditionFlat[] memory conditions) internal pure {
+        if (conditions.length > MAX_CONDITION_COUNT) {
+            revert IRolesError.ConditionNodeCountExceedsMax();
+        }
+
         _validateBFS(conditions);
 
         for (uint256 i = 0; i < conditions.length; ++i) {
+            _validatePackedWidths(conditions, i);
             _validateOperator(conditions, i);
             _validateEncoding(conditions, i);
         }
 
         _validateVariantTypes(conditions);
         _validatePluckZipTypes(conditions);
-        _validatePluckOrder(conditions, 0, 0);
+        _validateUniquePluckDefinitions(conditions);
+        _validatePluckAssignments(conditions, 0, 0);
+    }
+
+    function _validatePackedWidths(
+        ConditionFlat[] memory conditions,
+        uint256 index
+    ) private pure {
+        if (conditions[index].compValue.length > MAX_COMP_VALUE_LENGTH) {
+            revert IRolesError.UnsuitableCompValue(index);
+        }
+
+        (, uint256 childCount) = Topology.childBounds(conditions, index);
+        if (childCount > MAX_CHILD_COUNT) {
+            revert IRolesError.ConditionChildCountExceedsMax(index);
+        }
+
+        if (
+            Topology.isInlined(conditions, index) &&
+            Topology.inlinedSize(conditions, index) > MAX_INLINED_SIZE
+        ) {
+            revert IRolesError.ConditionInlinedSizeExceedsMax(index);
+        }
     }
 
     function _validateBFS(ConditionFlat[] memory conditions) private pure {
@@ -343,7 +375,7 @@ library Integrity {
             }
             seen |= mask;
 
-            (bool found, uint256 pluckCondition) = _findPluckedArray(
+            (bool found, uint256 pluckCondition) = _findPluck(
                 conditions,
                 pluckIndex
             );
@@ -398,9 +430,12 @@ library Integrity {
     ) private pure {
         ConditionFlat memory condition = conditions[index];
         Encoding encoding = condition.paramType;
-        // ParamType: any encoding except None (None is reserved for operators
-        // that do not target a calldata value, e.g. And/Or/Empty/ZipSome/...)
-        if (encoding == Encoding.None) {
+        // ParamType: Static / EtherValue / Array
+        if (
+            encoding != Encoding.Static &&
+            encoding != Encoding.EtherValue &&
+            encoding != Encoding.Array
+        ) {
             revert IRolesError.UnsuitableParameterType(index);
         }
         // CompValue: 1 byte holding the pluck slot index. The packed buffer
@@ -446,8 +481,19 @@ library Integrity {
             unsuitable = condition.compValue.length != 32;
         }
 
+        if (enc == Encoding.Dynamic) {
+            unsuitable =
+                condition.compValue.length < 64 ||
+                condition.compValue.length > MAX_COMP_VALUE_LENGTH;
+        }
+
         if (enc == Encoding.Tuple || enc == Encoding.Array) {
-            unsuitable = condition.compValue.length < 32;
+            uint256 minimumLength = Topology.isInlined(conditions, index)
+                ? 32
+                : 64;
+            unsuitable =
+                condition.compValue.length < minimumLength ||
+                condition.compValue.length > MAX_COMP_VALUE_LENGTH;
         }
 
         if (unsuitable) {
@@ -484,6 +530,7 @@ library Integrity {
         // CompValue: 2 shift + 2N
         if (
             condition.compValue.length < 4 ||
+            condition.compValue.length > MAX_COMP_VALUE_LENGTH ||
             (condition.compValue.length - 2) % 2 != 0
         ) {
             revert IRolesError.UnsuitableCompValue(index);
@@ -495,8 +542,20 @@ library Integrity {
         uint256 index
     ) private pure {
         ConditionFlat memory condition = conditions[index];
-        // CompValue: >= 20 bytes
-        if (condition.compValue.length < 20) {
+        if (
+            condition.paramType != Encoding.Static &&
+            condition.paramType != Encoding.Dynamic &&
+            condition.paramType != Encoding.Tuple &&
+            condition.paramType != Encoding.Array &&
+            condition.paramType != Encoding.EtherValue
+        ) {
+            revert IRolesError.UnsuitableParameterType(index);
+        }
+        // CompValue: 20 to 65535 bytes
+        if (
+            condition.compValue.length < 20 ||
+            condition.compValue.length > MAX_COMP_VALUE_LENGTH
+        ) {
             revert IRolesError.UnsuitableCompValue(index);
         }
     }
@@ -513,7 +572,7 @@ library Integrity {
         // CompValue: 12 base, optionally followed by adapter blobs.
         {
             uint256 len = condition.compValue.length;
-            if (len < 12) {
+            if (len < 12 || len > MAX_COMP_VALUE_LENGTH) {
                 revert IRolesError.UnsuitableCompValue(index);
             }
             uint256 offset = 12;
@@ -525,6 +584,26 @@ library Integrity {
             }
             if (len != offset) {
                 revert IRolesError.UnsuitableCompValue(index);
+            }
+        }
+        if (
+            uint8(condition.compValue[1]) > 27 ||
+            uint8(condition.compValue[3]) > 27
+        ) {
+            revert IRolesError.AllowanceDecimalsExceedMax(index);
+        }
+
+        for (uint256 offset; offset <= 2; offset += 2) {
+            (bool found, uint256 pluckCondition) = _findPluck(
+                conditions,
+                uint8(condition.compValue[offset])
+            );
+            if (
+                found &&
+                conditions[pluckCondition].paramType != Encoding.Static &&
+                conditions[pluckCondition].paramType != Encoding.EtherValue
+            ) {
+                revert IRolesError.WithinRatioTargetNotStatic(index);
             }
         }
         // Check ratio bounds
@@ -557,9 +636,10 @@ library Integrity {
         }
         // CompValue: 32, 34, or >= 54
         if (
-            condition.compValue.length != 32 &&
-            condition.compValue.length != 34 &&
-            condition.compValue.length < 54
+            condition.compValue.length > MAX_COMP_VALUE_LENGTH ||
+            (condition.compValue.length != 32 &&
+                condition.compValue.length != 34 &&
+                condition.compValue.length < 54)
         ) {
             revert IRolesError.UnsuitableCompValue(index);
         }
@@ -640,10 +720,13 @@ library Integrity {
             Layout memory tuple = TypeTree.resolve(conditions, childStart);
 
             for (uint256 j = 0; j < tuple.children.length; ++j) {
-                (, uint256 pluckCondition) = _findPluckedArray(
+                (bool found, uint256 pluckCondition) = _findPluck(
                     conditions,
                     uint8(conditions[i].compValue[j])
                 );
+                if (!found) {
+                    revert IRolesError.UnsuitableCompValue(i);
+                }
                 Layout memory array = TypeTree.resolve(
                     conditions,
                     pluckCondition
@@ -659,33 +742,56 @@ library Integrity {
         }
     }
 
+    function _validateUniquePluckDefinitions(
+        ConditionFlat[] memory conditions
+    ) private pure {
+        uint256 defined;
+        for (uint256 i; i < conditions.length; ++i) {
+            if (conditions[i].operator != Operator.Pluck) continue;
+
+            uint8 pluckIndex = uint8(conditions[i].compValue[0]);
+            uint256 mask = 1 << pluckIndex;
+            if ((defined & mask) != 0) {
+                revert IRolesError.DuplicatePluckIndex(i, pluckIndex);
+            }
+            defined |= mask;
+        }
+    }
+
     /**
-     * @notice Validates plucked variable definitions precede their usage.
+     * @notice Walks a subtree and returns the set of Pluck slots guaranteed
+     *         to hold a value once that subtree evaluates successfully.
+     *         Reverts if an operator reads a slot (WithinRatio, ZipSome,
+     *         ZipEvery) that may still be empty at that point.
      *
-     * @dev Evaluation happens in DFS order, so this function must check that
-     *      definitions come before usages in DFS order.
-     *
-     *      While the flat `conditions` array is stored in BFS order (parents
-     *      first), this function traverses the tree in DFS order to track the
-     *      `visited` state of plucked variables. This ensures that a
-     *      `WithinRatio` check can only reference variables that have been
-     *      "plucked" by a preceding condition in the execution flow.
+     * @dev A slot is only "guaranteed" if every evaluation path that leads
+     *      to success fills it:
+     *      - And/Matches run children in order, so each child sees the slots
+     *        filled by its predecessors, and its own additions carry forward.
+     *      - Or: any single branch may be the one that succeeded, so only
+     *        slots filled by every branch are guaranteed.
+     *      - Some succeeds only if at least one element was actually
+     *        evaluated, so its child's assignments count.
+     *      - Every passes trivially on an empty collection — its child may
+     *        never run, so nothing it assigns can be counted on.
+     *      Children of Pass, Pluck, comparisons, and Custom only describe
+     *      types and are never evaluated, so they are skipped.
      */
-    function _validatePluckOrder(
+    function _validatePluckAssignments(
         ConditionFlat[] memory conditions,
         uint256 index,
-        uint256 visited
+        uint256 assigned
     ) private pure returns (uint256) {
         ConditionFlat memory condition = conditions[index];
 
         if (condition.operator == Operator.Pluck) {
             uint8 pluckIndex = uint8(condition.compValue[0]);
-            visited |= (1 << pluckIndex);
+            return assigned | (1 << pluckIndex);
         }
 
         if (condition.operator == Operator.WithinRatio) {
             uint8 referencePluckIndex = uint8(condition.compValue[0]);
-            if ((visited & (1 << referencePluckIndex)) == 0) {
+            if ((assigned & (1 << referencePluckIndex)) == 0) {
                 revert IRolesError.PluckNotVisitedBeforeRef(
                     index,
                     referencePluckIndex
@@ -693,7 +799,7 @@ library Integrity {
             }
 
             uint8 relativePluckIndex = uint8(condition.compValue[2]);
-            if ((visited & (1 << relativePluckIndex)) == 0) {
+            if ((assigned & (1 << relativePluckIndex)) == 0) {
                 revert IRolesError.PluckNotVisitedBeforeRef(
                     index,
                     relativePluckIndex
@@ -707,7 +813,7 @@ library Integrity {
         ) {
             for (uint256 k; k < condition.compValue.length; ++k) {
                 uint8 pluckIndex = uint8(condition.compValue[k]);
-                if ((visited & (1 << pluckIndex)) == 0) {
+                if ((assigned & (1 << pluckIndex)) == 0) {
                     revert IRolesError.PluckNotVisitedBeforeRef(
                         index,
                         pluckIndex
@@ -716,16 +822,72 @@ library Integrity {
             }
         }
 
+        Operator op = condition.operator;
         (uint256 childStart, uint256 childCount) = Topology.childBounds(
             conditions,
             index
         );
 
-        for (uint256 i = 0; i < childCount; ++i) {
-            visited = _validatePluckOrder(conditions, childStart + i, visited);
+        if (op == Operator.Or) {
+            uint256 intersection;
+            for (uint256 i; i < childCount; ++i) {
+                uint256 branchAssigned = _validatePluckAssignments(
+                    conditions,
+                    childStart + i,
+                    assigned
+                );
+                intersection = i == 0
+                    ? branchAssigned
+                    : intersection & branchAssigned;
+            }
+            return intersection;
         }
 
-        return visited;
+        if (op == Operator.ArraySome || op == Operator.ArrayEvery) {
+            uint256 childAssigned = _validatePluckAssignments(
+                conditions,
+                childStart,
+                assigned
+            );
+            return op == Operator.ArraySome ? childAssigned : assigned;
+        }
+
+        if (op == Operator.ZipSome || op == Operator.ZipEvery) {
+            (uint256 fieldStart, uint256 fieldCount) = Topology.childBounds(
+                conditions,
+                childStart
+            );
+            uint256 fieldAssigned = assigned;
+            for (uint256 i; i < fieldCount; ++i) {
+                fieldAssigned = _validatePluckAssignments(
+                    conditions,
+                    fieldStart + i,
+                    fieldAssigned
+                );
+            }
+            return op == Operator.ZipSome ? fieldAssigned : assigned;
+        }
+
+        if (
+            op == Operator.And ||
+            op == Operator.Matches ||
+            op == Operator.ArrayTailMatches
+        ) {
+            for (uint256 i; i < childCount; ++i) {
+                assigned = _validatePluckAssignments(
+                    conditions,
+                    childStart + i,
+                    assigned
+                );
+            }
+            return assigned;
+        }
+
+        if (op == Operator.Slice) {
+            return _validatePluckAssignments(conditions, childStart, assigned);
+        }
+
+        return assigned;
     }
 
     function _validateNoPluckDescendant(
@@ -803,7 +965,7 @@ library Integrity {
      * @notice Finds the conditions index of the Pluck condition with the given
      *         pluck index.
      */
-    function _findPluckedArray(
+    function _findPluck(
         ConditionFlat[] memory conditions,
         uint8 pluckIndex
     ) private pure returns (bool found, uint256 conditionIndex) {

--- a/packages/evm/contracts/types/Operator.sol
+++ b/packages/evm/contracts/types/Operator.sol
@@ -42,7 +42,7 @@ enum Operator {
     //          ❓ children (at most one child, must resolve to Static)
     //          ✅ compValue
     /* 13: */ Slice, // paramType: Static / Dynamic, compValue: 3 bytes (2 bytes shift + 1 byte size, 1-32)
-    /* 14: */ Pluck, // paramType: Static / EtherValue / Array, compValue: 1 byte (index into pluckedValues, 0-255)
+    /* 14: */ Pluck, // paramType: Static / EtherValue / Array, compValue: 1 byte (index into pluckedValues, 0-254)
     // ------------------------------------------------------------
     // 15:    SPECIAL COMPARISON (without compValue)
     //          paramType: Static

--- a/packages/evm/contracts/types/RolesError.sol
+++ b/packages/evm/contracts/types/RolesError.sol
@@ -80,6 +80,15 @@ interface IRolesError {
     /// Comparison value is unsuitable for the operator at given index
     error UnsuitableCompValue(uint256 index);
 
+    /// Condition count exceeds the packed header's 16-bit field
+    error ConditionNodeCountExceedsMax();
+
+    /// Child count exceeds the packed node's 10-bit field
+    error ConditionChildCountExceedsMax(uint256 index);
+
+    /// Inlined size exceeds the packed node's 13-bit field
+    error ConditionInlinedSizeExceedsMax(uint256 index);
+
     /// Operator is not supported at given index
     error UnsupportedOperator(uint256 index);
 
@@ -101,14 +110,17 @@ interface IRolesError {
     /// WithinRatio requires at least one ratio (min or max) to be provided
     error WithinRatioNoRatioProvided(uint256 index);
 
-    /// Allowance decimals exceed maximum of 18
+    /// Allowance decimals exceed maximum of 27
     error AllowanceDecimalsExceedMax(uint256 index);
 
     /// Slice child must resolve to Static type
     error SliceChildNotStatic(uint256 index);
 
-    /// WithinRatio references a Pluck index that hasn't been visited yet in DFS order
+    /// An operator references a Pluck slot that is not definitely assigned
     error PluckNotVisitedBeforeRef(uint256 index, uint8 pluckIndex);
+
+    /// A Pluck slot is defined more than once in the condition tree
+    error DuplicatePluckIndex(uint256 index, uint8 pluckIndex);
 
     /// address(0) is not allowed
     error ZeroAddressNotAllowed();

--- a/packages/evm/test/operators/14Pluck.spec.ts
+++ b/packages/evm/test/operators/14Pluck.spec.ts
@@ -20,16 +20,25 @@ describe("Operator - Pluck", () => {
 
       // Note: Array is now allowed for Pluck (used by Zip operators)
 
-      await expect(
-        packConditions(roles, [
-          {
-            parent: 0,
-            paramType: Encoding.None,
-            operator: Operator.Pluck,
-            compValue: "0x00",
-          },
-        ]),
-      ).to.be.revertedWithCustomError(roles, "UnsuitableParameterType");
+      for (const encoding of [
+        Encoding.None,
+        Encoding.Dynamic,
+        Encoding.Tuple,
+        Encoding.AbiEncoded,
+      ]) {
+        await expect(
+          packConditions(roles, [
+            {
+              parent: 0,
+              paramType: encoding,
+              operator: Operator.Pluck,
+              compValue: "0x00",
+            },
+          ]),
+        )
+          .to.be.revertedWithCustomError(roles, "UnsuitableParameterType")
+          .withArgs(0);
+      }
     });
 
     describe("compValue", () => {

--- a/packages/evm/test/operators/22Custom.spec.ts
+++ b/packages/evm/test/operators/22Custom.spec.ts
@@ -429,6 +429,25 @@ describe("Operator - Custom", () => {
   });
 
   describe("integrity", () => {
+    it("reverts UnsuitableParameterType for None and AbiEncoded", async () => {
+      const { roles } = await loadFixture(setupTestContract);
+
+      for (const encoding of [Encoding.None, Encoding.AbiEncoded]) {
+        await expect(
+          packConditions(roles, [
+            {
+              parent: 0,
+              paramType: encoding,
+              operator: Operator.Custom,
+              compValue: "0x" + "00".repeat(20),
+            },
+          ]),
+        )
+          .to.be.revertedWithCustomError(roles, "UnsuitableParameterType")
+          .withArgs(0);
+      }
+    });
+
     it("reverts UnsuitableCompValue when compValue is less than 20 bytes", async () => {
       const { roles } = await loadFixture(setupTestContract);
 

--- a/packages/evm/test/operators/23WithinRatio.spec.ts
+++ b/packages/evm/test/operators/23WithinRatio.spec.ts
@@ -345,11 +345,11 @@ describe("Operator - WithinRatio", () => {
           );
       });
 
-      it("handles extreme decimal difference with adapters (6 vs 37 decimals)", async () => {
+      it("handles maximum decimal difference with adapters (6 vs 27 decimals)", async () => {
         const { roles, allowFunction, invoke } =
           await loadFixture(setupTwoParams);
 
-        // Reference: USDC (6 decimals), Relative: ExoticToken (37 decimals)
+        // Reference: USDC (6 decimals), Relative: ExoticToken (27 decimals)
         // Reference adapter: 1 USDC = 1 USD (stable)
         // Relative adapter: 1 ExoticToken = 0.5 USD
         const MockPricing = await ethers.getContractFactory("MockPricing");
@@ -362,7 +362,7 @@ describe("Operator - WithinRatio", () => {
           referencePluckIndex: 77,
           referenceDecimals: 6,
           relativePluckIndex: 88,
-          relativeDecimals: 37,
+          relativeDecimals: 27,
           minRatio: 9900,
           maxRatio: 10100,
         });
@@ -375,16 +375,16 @@ describe("Operator - WithinRatio", () => {
         // Relative: 2000 ExoticToken × 0.5 = 1000 USD
         // Ratio = 100%
         await expect(
-          invoke(1000n * 10n ** 6n, 2000n * 10n ** 37n),
+          invoke(1000n * 10n ** 6n, 2000n * 10n ** 27n),
         ).to.not.be.revert(ethers);
 
         // Relative: 2020 ExoticToken × 0.5 = 1010 USD → 101%
         await expect(
-          invoke(1000n * 10n ** 6n, 2020n * 10n ** 37n),
+          invoke(1000n * 10n ** 6n, 2020n * 10n ** 27n),
         ).to.not.be.revert(ethers);
 
         // Relative: 2030 ExoticToken × 0.5 = 1015 USD → 101.5% > 101%
-        await expect(invoke(1000n * 10n ** 6n, 2030n * 10n ** 37n))
+        await expect(invoke(1000n * 10n ** 6n, 2030n * 10n ** 27n))
           .to.be.revertedWithCustomError(roles, "ConditionViolation")
           .withArgs(
             ConditionViolationStatus.RatioAboveMax,
@@ -1310,7 +1310,7 @@ describe("Operator - WithinRatio", () => {
         );
     });
 
-    it("USDC/exotic token swap - extreme decimal difference", async () => {
+    it("USDC/exotic token swap - maximum decimal difference", async () => {
       const { roles, allowFunction, invoke } =
         await loadFixture(setupTwoParams);
 
@@ -1325,7 +1325,7 @@ describe("Operator - WithinRatio", () => {
         referencePluckIndex: 83,
         referenceDecimals: 6, // USDC
         relativePluckIndex: 61,
-        relativeDecimals: 37, // ExoticToken
+        relativeDecimals: 27, // ExoticToken
         minRatio: 9975, // 99.75%
         maxRatio: 10025, // 100.25%
       });
@@ -1337,11 +1337,11 @@ describe("Operator - WithinRatio", () => {
       // invoke(relative, reference) since param0→relative (ExoticToken), param1→reference (USDC)
       // Selling 1000 USDC for 500 ExoticToken → (500 × 2) / 1000 = 100%
       await expect(
-        invoke(500n * 10n ** 37n, 1000n * 10n ** 6n),
+        invoke(500n * 10n ** 27n, 1000n * 10n ** 6n),
       ).to.not.be.revert(ethers);
 
       // Selling 1000 USDC for 498.7 ExoticToken → 99.74% < 99.75%
-      await expect(invoke(4987n * 10n ** 34n, 1000n * 10n ** 6n))
+      await expect(invoke(4987n * 10n ** 24n, 1000n * 10n ** 6n))
         .to.be.revertedWithCustomError(roles, "ConditionViolation")
         .withArgs(
           ConditionViolationStatus.RatioBelowMin,
@@ -2525,6 +2525,56 @@ describe("integrity", () => {
           },
         ]),
       ).to.be.revertedWithCustomError(roles, "UnsuitableCompValue");
+    });
+
+    it("reverts AllowanceDecimalsExceedMax when referenceDecimals exceeds 27", async () => {
+      const { roles } = await loadFixture(setupTestContract);
+      const compValue = encodeWithinRatioCompValue({
+        referencePluckIndex: 0,
+        referenceDecimals: 28,
+        relativePluckIndex: 1,
+        relativeDecimals: 18,
+        minRatio: 9000,
+        maxRatio: 11000,
+      });
+
+      await expect(
+        packConditions(roles, [
+          {
+            parent: 0,
+            paramType: Encoding.None,
+            operator: Operator.WithinRatio,
+            compValue,
+          },
+        ]),
+      )
+        .to.be.revertedWithCustomError(roles, "AllowanceDecimalsExceedMax")
+        .withArgs(0);
+    });
+
+    it("reverts AllowanceDecimalsExceedMax when relativeDecimals exceeds 27", async () => {
+      const { roles } = await loadFixture(setupTestContract);
+      const compValue = encodeWithinRatioCompValue({
+        referencePluckIndex: 0,
+        referenceDecimals: 18,
+        relativePluckIndex: 1,
+        relativeDecimals: 28,
+        minRatio: 9000,
+        maxRatio: 11000,
+      });
+
+      await expect(
+        packConditions(roles, [
+          {
+            parent: 0,
+            paramType: Encoding.None,
+            operator: Operator.WithinRatio,
+            compValue,
+          },
+        ]),
+      )
+        .to.be.revertedWithCustomError(roles, "AllowanceDecimalsExceedMax")
+        .withArgs(0);
     });
 
     it("accepts compValue with adapter params", async () => {

--- a/packages/evm/test/serialization/evaluator-dispatch.spec.ts
+++ b/packages/evm/test/serialization/evaluator-dispatch.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import { network } from "hardhat";
+
+import { Operator } from "../utils.js";
+
+const connection = await network.create();
+const { ethers } = connection;
+
+describe("ConditionEvaluator dispatch", () => {
+  after(async () => {
+    await connection.close();
+  });
+
+  it("fails closed for unsupported operators", async () => {
+    const Evaluator = await ethers.getContractFactory(
+      "MockConditionEvaluator",
+      {
+        libraries: {
+          WithinRatioChecker: "0x0000000000000000000000000000000000000001",
+        },
+      },
+    );
+    const evaluator = await Evaluator.deploy();
+
+    for (const op of [
+      Operator._Placeholder03,
+      Operator._Placeholder24,
+      Operator._Placeholder31,
+    ]) {
+      await expect(evaluator.evaluate("0x", op))
+        .to.be.revertedWithCustomError(evaluator, "UnsupportedOperator")
+        .withArgs(7);
+    }
+  });
+});

--- a/packages/evm/test/serialization/integrity.spec.ts
+++ b/packages/evm/test/serialization/integrity.spec.ts
@@ -656,27 +656,6 @@ describe("Integrity", () => {
           .withArgs(0);
       });
 
-      it("reverts when an inlined node exceeds 8191 bytes", async () => {
-        const { roles, pack } = await loadFixture(setup);
-
-        await expect(
-          pack(
-            flattenCondition({
-              paramType: Encoding.Tuple,
-              operator: Operator.Matches,
-              children: Array.from({ length: 256 }, () => ({
-                paramType: Encoding.Static,
-                operator: Operator.Pass,
-              })),
-            }),
-          ),
-        )
-          .to.be.revertedWithCustomError(
-            roles,
-            "ConditionInlinedSizeExceedsMax",
-          )
-          .withArgs(0);
-      });
     });
 
     describe("additional operator constraints", () => {

--- a/packages/evm/test/serialization/integrity.spec.ts
+++ b/packages/evm/test/serialization/integrity.spec.ts
@@ -14,6 +14,7 @@ const connection = await network.create();
 const { ethers, networkHelpers } = connection;
 const { loadFixture } = networkHelpers;
 const { deployRolesMod } = createSetup(connection);
+const oversizedCompValue = "0x" + "00".repeat(65536);
 
 describe("Integrity", () => {
   after(async () => {
@@ -259,7 +260,7 @@ describe("Integrity", () => {
               parent: 0,
               paramType: Encoding.Dynamic,
               operator: Operator.EqualTo,
-              compValue: ethers.keccak256("0xaabbccdd"),
+              compValue: "0x" + "00".repeat(64),
             },
             {
               parent: 0,
@@ -582,6 +583,152 @@ describe("Integrity", () => {
           ),
         ).to.be.revertedWithCustomError(roles, "UnsuitableCompValue");
       });
+
+      for (const encoding of [Encoding.Tuple, Encoding.Array]) {
+        it(`reverts UnsuitableCompValue for ${Encoding[encoding]} EqualTo when compValue exceeds 65535 bytes`, async () => {
+          const { roles, pack } = await loadFixture(setup);
+
+          await expect(
+            pack(
+              flattenCondition({
+                paramType: encoding,
+                operator: Operator.EqualTo,
+                compValue: oversizedCompValue,
+                children: [
+                  {
+                    paramType: Encoding.Static,
+                    operator: Operator.Pass,
+                  },
+                ],
+              }),
+            ),
+          )
+            .to.be.revertedWithCustomError(roles, "UnsuitableCompValue")
+            .withArgs(0);
+        });
+      }
+    });
+
+    describe("maximum compValue length", () => {
+      for (const [name, paramType, operator] of [
+        ["Bitmask", Encoding.Static, Operator.Bitmask],
+        ["Custom", Encoding.Static, Operator.Custom],
+        ["WithinAllowance", Encoding.Static, Operator.WithinAllowance],
+        ["WithinRatio", Encoding.None, Operator.WithinRatio],
+        ["Dynamic EqualTo", Encoding.Dynamic, Operator.EqualTo],
+      ] as const) {
+        it(`reverts UnsuitableCompValue for ${name} when compValue exceeds 65535 bytes`, async () => {
+          const { roles, pack } = await loadFixture(setup);
+
+          await expect(
+            pack([
+              {
+                parent: 0,
+                paramType,
+                operator,
+                compValue: oversizedCompValue,
+              },
+            ]),
+          )
+            .to.be.revertedWithCustomError(roles, "UnsuitableCompValue")
+            .withArgs(0);
+        });
+      }
+    });
+
+    describe("packed field widths", () => {
+      it("reverts when a node has more than 1023 children", async () => {
+        const { roles, pack } = await loadFixture(setup);
+
+        await expect(
+          pack(
+            flattenCondition({
+              paramType: Encoding.None,
+              operator: Operator.And,
+              children: Array.from({ length: 1024 }, () => ({
+                paramType: Encoding.Static,
+                operator: Operator.Pass,
+              })),
+            }),
+          ),
+        )
+          .to.be.revertedWithCustomError(roles, "ConditionChildCountExceedsMax")
+          .withArgs(0);
+      });
+
+      it("reverts when an inlined node exceeds 8191 bytes", async () => {
+        const { roles, pack } = await loadFixture(setup);
+
+        await expect(
+          pack(
+            flattenCondition({
+              paramType: Encoding.Tuple,
+              operator: Operator.Matches,
+              children: Array.from({ length: 256 }, () => ({
+                paramType: Encoding.Static,
+                operator: Operator.Pass,
+              })),
+            }),
+          ),
+        )
+          .to.be.revertedWithCustomError(
+            roles,
+            "ConditionInlinedSizeExceedsMax",
+          )
+          .withArgs(0);
+      });
+    });
+
+    describe("additional operator constraints", () => {
+      it("reverts Dynamic EqualTo with less than one ABI head and tail word", async () => {
+        const { roles, pack } = await loadFixture(setup);
+
+        await expect(
+          pack([
+            {
+              parent: 0,
+              paramType: Encoding.Dynamic,
+              operator: Operator.EqualTo,
+              compValue: "0x" + "00".repeat(32),
+            },
+          ]),
+        )
+          .to.be.revertedWithCustomError(roles, "UnsuitableCompValue")
+          .withArgs(0);
+      });
+
+      it("reverts WithinRatio references to an Array Pluck", async () => {
+        const { roles, pack } = await loadFixture(setup);
+
+        await expect(
+          pack(
+            flattenCondition({
+              paramType: Encoding.None,
+              operator: Operator.And,
+              children: [
+                {
+                  paramType: Encoding.Array,
+                  operator: Operator.Pluck,
+                  compValue: "0x00",
+                  children: [
+                    {
+                      paramType: Encoding.Static,
+                      operator: Operator.Pass,
+                    },
+                  ],
+                },
+                {
+                  paramType: Encoding.None,
+                  operator: Operator.WithinRatio,
+                  compValue: "0x000000000000232800002af8",
+                },
+              ],
+            }),
+          ),
+        )
+          .to.be.revertedWithCustomError(roles, "WithinRatioTargetNotStatic")
+          .withArgs(2);
+      });
     });
 
     describe("Slice child constraint", () => {
@@ -609,7 +756,7 @@ describe("Integrity", () => {
   });
 
   // 4. CROSS-NODE DEPENDENCIES
-  describe("pluck order", () => {
+  describe("pluck definite assignment", () => {
     it("reverts PluckNotVisitedBeforeRef when WithinRatio references unvisited pluck index", async () => {
       const { roles, pack } = await loadFixture(setup);
 
@@ -852,6 +999,191 @@ describe("Integrity", () => {
           }),
         ),
       ).to.not.be.revert(ethers);
+    });
+
+    it("rejects Plucks hidden below Pass", async () => {
+      const { roles, pack } = await loadFixture(setup);
+
+      await expect(
+        pack(
+          flattenCondition({
+            paramType: Encoding.None,
+            operator: Operator.And,
+            children: [
+              {
+                paramType: Encoding.Tuple,
+                operator: Operator.Pass,
+                children: [
+                  {
+                    paramType: Encoding.Static,
+                    operator: Operator.Pluck,
+                    compValue: "0x00",
+                  },
+                  {
+                    paramType: Encoding.Static,
+                    operator: Operator.Pluck,
+                    compValue: "0x01",
+                  },
+                ],
+              },
+              {
+                paramType: Encoding.None,
+                operator: Operator.WithinRatio,
+                compValue: "0x000001000000232800002af8",
+              },
+            ],
+          }),
+        ),
+      )
+        .to.be.revertedWithCustomError(roles, "PluckNotVisitedBeforeRef")
+        .withArgs(2, 0);
+    });
+
+    it("intersects Pluck assignments across Or branches", async () => {
+      const { roles, pack } = await loadFixture(setup);
+
+      await expect(
+        pack(
+          flattenCondition({
+            paramType: Encoding.None,
+            operator: Operator.And,
+            children: [
+              {
+                paramType: Encoding.Static,
+                operator: Operator.Pluck,
+                compValue: "0x01",
+              },
+              {
+                paramType: Encoding.None,
+                operator: Operator.Or,
+                children: [
+                  {
+                    paramType: Encoding.Static,
+                    operator: Operator.Pluck,
+                    compValue: "0x00",
+                  },
+                  {
+                    paramType: Encoding.Static,
+                    operator: Operator.Pass,
+                  },
+                ],
+              },
+              {
+                paramType: Encoding.None,
+                operator: Operator.WithinRatio,
+                compValue: "0x000001000000232800002af8",
+              },
+            ],
+          }),
+        ),
+      )
+        .to.be.revertedWithCustomError(roles, "PluckNotVisitedBeforeRef")
+        .withArgs(3, 0);
+    });
+
+    it("does not export Pluck assignments from ArrayEvery", async () => {
+      const { roles, pack } = await loadFixture(setup);
+
+      await expect(
+        pack(
+          flattenCondition({
+            paramType: Encoding.None,
+            operator: Operator.And,
+            children: [
+              {
+                paramType: Encoding.Array,
+                operator: Operator.ArrayEvery,
+                children: [
+                  {
+                    paramType: Encoding.None,
+                    operator: Operator.And,
+                    children: [
+                      {
+                        paramType: Encoding.Static,
+                        operator: Operator.Pluck,
+                        compValue: "0x00",
+                      },
+                      {
+                        paramType: Encoding.Static,
+                        operator: Operator.Pluck,
+                        compValue: "0x01",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                paramType: Encoding.None,
+                operator: Operator.WithinRatio,
+                compValue: "0x000001000000232800002af8",
+              },
+            ],
+          }),
+        ),
+      )
+        .to.be.revertedWithCustomError(roles, "PluckNotVisitedBeforeRef")
+        .withArgs(2, 0);
+    });
+
+    it("rejects duplicate Pluck definitions", async () => {
+      const { roles, pack } = await loadFixture(setup);
+
+      await expect(
+        pack(
+          flattenCondition({
+            paramType: Encoding.None,
+            operator: Operator.And,
+            children: [
+              {
+                paramType: Encoding.Static,
+                operator: Operator.Pluck,
+                compValue: "0x00",
+              },
+              {
+                paramType: Encoding.Static,
+                operator: Operator.Pluck,
+                compValue: "0x00",
+              },
+            ],
+          }),
+        ),
+      )
+        .to.be.revertedWithCustomError(roles, "DuplicatePluckIndex")
+        .withArgs(2, 0);
+    });
+
+    it("does not visit Plucks below an Array Pluck", async () => {
+      const { roles, pack } = await loadFixture(setup);
+
+      await expect(
+        pack(
+          flattenCondition({
+            paramType: Encoding.None,
+            operator: Operator.And,
+            children: [
+              {
+                paramType: Encoding.Array,
+                operator: Operator.Pluck,
+                compValue: "0x00",
+                children: [
+                  {
+                    paramType: Encoding.Static,
+                    operator: Operator.Pluck,
+                    compValue: "0x01",
+                  },
+                ],
+              },
+              {
+                paramType: Encoding.None,
+                operator: Operator.WithinRatio,
+                compValue: "0x010001000000232800002af8",
+              },
+            ],
+          }),
+        ),
+      )
+        .to.be.revertedWithCustomError(roles, "PluckNotVisitedBeforeRef")
+        .withArgs(2, 1);
     });
   });
 });


### PR DESCRIPTION
This PR tightens Integrity checks.

It adds bounds checks for fields that have a fixed size in the packed format, including the number of conditions, child counts, inlined sizes, and comparison value lengths. Caps WithinRatio decimals at 27 and improves validation around EqualTo, Custom, and Pluck-based conditions.

Pluck validation now better reflects how conditions are actually evaluated. References must be assigned on every possible execution path, duplicate indices are rejected, and WithinRatio and Zip conditions must reference compatible values.

We also explicitly reverts with UnsupportedOperator for unused operator slots, instead of asserting.